### PR TITLE
🔧 skip using image loader

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,6 @@ import 'src/env';
 
 const nextConfig: NextConfig = {
   images: {
-    loader: 'custom',
-    loaderFile: './src/loader.ts',
     formats: ['image/avif', 'image/webp'],
     qualities: [25, 50, 75, 85],
     remotePatterns: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched image handling to the default loader, removing the custom image loader configuration.
  * Existing image settings (formats, quality, remote source patterns) remain unchanged, ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->