### PR TITLE
💄 fix circular person avatars not being fully round

### DIFF
--- a/src/app/movie/[movieId]/page.tsx
+++ b/src/app/movie/[movieId]/page.tsx
@@ -247,15 +247,17 @@ export default async function MoviePage(props: MoviePageProps) {
                     className="flex items-center gap-3 rounded-lg bg-zinc-800 p-3 transition-colors hover:bg-zinc-700"
                   >
                     {director.profile_path ? (
-                      <Imgproxy
-                        src={director.profile_path}
-                        alt={director.name}
-                        width={185}
-                        height={40}
-                        className="h-10 w-10 rounded-full object-cover"
-                      />
+                      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                        <Imgproxy
+                          src={director.profile_path}
+                          alt={director.name}
+                          width={40}
+                          height={40}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
                     ) : (
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-zinc-700">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-zinc-700">
                         <Users className="h-5 w-5 text-zinc-400" />
                       </div>
                     )}
@@ -276,15 +278,17 @@ export default async function MoviePage(props: MoviePageProps) {
                     className="flex items-center gap-3 rounded-lg bg-zinc-800 p-3"
                   >
                     {writer.profile_path ? (
-                      <Imgproxy
-                        src={writer.profile_path}
-                        alt={writer.name}
-                        width={185}
-                        height={40}
-                        className="h-10 w-10 rounded-full object-cover"
-                      />
+                      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                        <Imgproxy
+                          src={writer.profile_path}
+                          alt={writer.name}
+                          width={40}
+                          height={40}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
                     ) : (
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-zinc-700">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-zinc-700">
                         <Users className="h-5 w-5 text-zinc-400" />
                       </div>
                     )}

--- a/src/app/movie/[movieId]/page.tsx
+++ b/src/app/movie/[movieId]/page.tsx
@@ -253,7 +253,7 @@ export default async function MoviePage(props: MoviePageProps) {
                           alt={director.name}
                           width={40}
                           height={40}
-                          className="h-full w-full object-cover"
+                          className="h-full w-full object-cover object-center"
                         />
                       </div>
                     ) : (
@@ -284,7 +284,7 @@ export default async function MoviePage(props: MoviePageProps) {
                           alt={writer.name}
                           width={40}
                           height={40}
-                          className="h-full w-full object-cover"
+                          className="h-full w-full object-cover object-center"
                         />
                       </div>
                     ) : (

--- a/src/app/tv/[tvId]/page.tsx
+++ b/src/app/tv/[tvId]/page.tsx
@@ -252,7 +252,7 @@ export default async function TvShowPage(props: TvShowPageProps) {
                           alt={creator.name}
                           width={40}
                           height={40}
-                          className="h-full w-full object-cover"
+                          className="h-full w-full object-cover object-center"
                         />
                       </div>
                     ) : (

--- a/src/app/tv/[tvId]/page.tsx
+++ b/src/app/tv/[tvId]/page.tsx
@@ -246,15 +246,17 @@ export default async function TvShowPage(props: TvShowPageProps) {
                     className="flex items-center gap-3 rounded-lg bg-zinc-800 p-3 transition-colors hover:bg-zinc-700"
                   >
                     {creator.profile_path ? (
-                      <Imgproxy
-                        src={creator.profile_path}
-                        alt={creator.name}
-                        width={92}
-                        height={40}
-                        className="h-10 w-10 rounded-full object-cover"
-                      />
+                      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                        <Imgproxy
+                          src={creator.profile_path}
+                          alt={creator.name}
+                          width={40}
+                          height={40}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
                     ) : (
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-zinc-700">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-zinc-700">
                         <Users className="h-5 w-5 text-zinc-400" />
                       </div>
                     )}


### PR DESCRIPTION
## Summary
- Director, writer, and creator avatars were not fully circular despite `rounded-full` styling
- Root cause: `Imgproxy.module.css` `.fit` class sets `height: auto` which overrode `h-10` on the `<img>`, making images non-square so `rounded-full` clipping didn't produce circles
- Fix: wrap `Imgproxy` in `overflow-hidden rounded-full` container div for all circular avatar usages (movie directors, movie writers, TV creators)

## Test plan
- [ ] Verify director avatars on movie detail pages are fully circular
- [ ] Verify writer avatars on movie detail pages are fully circular
- [ ] Verify creator avatars on TV show detail pages are fully circular
- [ ] Verify cast card images (portrait format) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)