### PR TITLE
🐛 fix blank landing page from streamed-hydration crash

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -4,22 +4,73 @@ import Trending from '@/app/trending';
 import ItemGrid from '@/components/item-grid';
 import MediaList from '@/components/media-list';
 import { ItemSlider } from '@/components/ui/item-slider';
-import {
-  fetchNowPlayingMovies,
-  fetchTopRatedMovies,
-  fetchUpcomingMovies,
-  fetchUserNowPlayingMovies,
-  fetchUserTopRatedMovies,
-  fetchUserUpcomingMovies,
-} from '@/lib/movies';
-import {
-  fetchOnTheAirTvShows,
-  fetchPopularTvShows,
-  fetchTopRatedTvShows,
-  fetchUserOnTheAirTvShows,
-  fetchUserPopularTvShows,
-  fetchUserTopRatedTvShows,
-} from '@/lib/tv-shows';
+import { fetchNowPlayingMovies, fetchTopRatedMovies, fetchUpcomingMovies } from '@/lib/movies';
+import { fetchOnTheAirTvShows, fetchPopularTvShows, fetchTopRatedTvShows } from '@/lib/tv-shows';
+import { Movie } from '@/types/movie';
+import { TvShow } from '@/types/tv-show';
+
+type MediaSectionConfig = {
+  heading: string;
+  caption: string;
+  type: 'movie' | 'tv';
+  fetchItems: () => Promise<Movie[] | TvShow[]>;
+};
+
+const SECTIONS: MediaSectionConfig[] = [
+  {
+    heading: 'Movies in Theaters',
+    caption: 'Now playing',
+    type: 'movie',
+    fetchItems: fetchNowPlayingMovies,
+  },
+  {
+    heading: 'TV Shows on Air',
+    caption: 'Currently airing',
+    type: 'tv',
+    fetchItems: fetchOnTheAirTvShows,
+  },
+  {
+    heading: 'Coming Soon',
+    caption: 'Upcoming movies',
+    type: 'movie',
+    fetchItems: fetchUpcomingMovies,
+  },
+  {
+    heading: 'Popular TV Shows',
+    caption: 'Trending series',
+    type: 'tv',
+    fetchItems: fetchPopularTvShows,
+  },
+  {
+    heading: 'Top Rated Movies',
+    caption: 'All-time favorites',
+    type: 'movie',
+    fetchItems: fetchTopRatedMovies,
+  },
+  {
+    heading: 'Top Rated TV Shows',
+    caption: 'Highest rated series',
+    type: 'tv',
+    fetchItems: fetchTopRatedTvShows,
+  },
+];
+
+function MediaSection({ heading, caption, type, fetchItems }: MediaSectionConfig) {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">{heading}</h2>
+        <p className="hidden text-sm text-muted-foreground sm:block">{caption}</p>
+      </div>
+
+      <ItemSlider>
+        <Suspense fallback={<ItemGrid.Skeletons />}>
+          <MediaList fetchItems={fetchItems} type={type} />
+        </Suspense>
+      </ItemSlider>
+    </section>
+  );
+}
 
 /**
  * Renders the homepage with categorized sections for trending, popular, and top-rated movies and TV shows.
@@ -28,7 +79,7 @@ import {
  *
  * @returns The structured homepage layout as a React element.
  */
-export default async function Home() {
+export default function Home() {
   return (
     <div className="space-y-8">
       <section className="space-y-4">
@@ -50,107 +101,9 @@ export default async function Home() {
         </div>
       </section>
 
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">Movies in Theaters</h2>
-          <p className="hidden text-sm text-muted-foreground sm:block">Now playing</p>
-        </div>
-
-        <ItemSlider>
-          <Suspense fallback={<ItemGrid.Skeletons />}>
-            <MediaList
-              fetchUserItems={fetchUserNowPlayingMovies}
-              fetchItems={fetchNowPlayingMovies}
-              type="movie"
-            />
-          </Suspense>
-        </ItemSlider>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">TV Shows on Air</h2>
-          <p className="hidden text-sm text-muted-foreground sm:block">Currently airing</p>
-        </div>
-
-        <ItemSlider>
-          <Suspense fallback={<ItemGrid.Skeletons />}>
-            <MediaList
-              fetchUserItems={fetchUserOnTheAirTvShows}
-              fetchItems={fetchOnTheAirTvShows}
-              type="tv"
-            />
-          </Suspense>
-        </ItemSlider>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">Coming Soon</h2>
-          <p className="hidden text-sm text-muted-foreground sm:block">Upcoming movies</p>
-        </div>
-
-        <ItemSlider>
-          <Suspense fallback={<ItemGrid.Skeletons />}>
-            <MediaList
-              fetchUserItems={fetchUserUpcomingMovies}
-              fetchItems={fetchUpcomingMovies}
-              type="movie"
-            />
-          </Suspense>
-        </ItemSlider>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">Popular TV Shows</h2>
-          <p className="hidden text-sm text-muted-foreground sm:block">Trending series</p>
-        </div>
-
-        <ItemSlider>
-          <Suspense fallback={<ItemGrid.Skeletons />}>
-            <MediaList
-              fetchUserItems={fetchUserPopularTvShows}
-              fetchItems={fetchPopularTvShows}
-              type="tv"
-            />
-          </Suspense>
-        </ItemSlider>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">Top Rated Movies</h2>
-          <p className="hidden text-sm text-muted-foreground sm:block">All-time favorites</p>
-        </div>
-
-        <ItemSlider>
-          <Suspense fallback={<ItemGrid.Skeletons />}>
-            <MediaList
-              fetchUserItems={fetchUserTopRatedMovies}
-              fetchItems={fetchTopRatedMovies}
-              type="movie"
-            />
-          </Suspense>
-        </ItemSlider>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold tracking-tight lg:text-2xl">Top Rated TV Shows</h2>
-          <p className="hidden text-sm text-muted-foreground sm:block">Highest rated series</p>
-        </div>
-
-        <ItemSlider>
-          <Suspense fallback={<ItemGrid.Skeletons />}>
-            <MediaList
-              fetchUserItems={fetchUserTopRatedTvShows}
-              fetchItems={fetchTopRatedTvShows}
-              type="tv"
-            />
-          </Suspense>
-        </ItemSlider>
-      </section>
+      {SECTIONS.map((section) => (
+        <MediaSection key={section.heading} {...section} />
+      ))}
     </div>
   );
 }

--- a/src/components/list-button.tsx
+++ b/src/components/list-button.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 
 import { CreateListDialog } from '@/components/create-list-dialog';
 import { Button } from '@/components/ui/button';
+import { useSession } from '@/lib/auth-client';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -125,11 +126,19 @@ function ListMenuItems({
   ));
 }
 
+// Prefer the server-provided id, but fall back to the client session so cards
+// rendered from prerendered (cached) lists still get the button once hydrated.
+function useResolvedUserId(userId?: string) {
+  const { data: session } = useSession();
+  return userId ?? session?.user?.id;
+}
+
 export function ListButton({ mediaId, mediaType, userId, showWatchlist = true }: ListButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isPending, setIsPending] = useState(false);
   const queryClient = useQueryClient();
+  const resolvedUserId = useResolvedUserId(userId);
 
   const { data: lists = [], isLoading: isLoadingLists } = useQuery({
     queryKey: queryKeys.lists.withStatus(mediaId, mediaType),
@@ -145,7 +154,7 @@ export function ListButton({ mediaId, mediaType, userId, showWatchlist = true }:
     enabled: isOpen && showWatchlist,
   });
 
-  if (!userId) {
+  if (!resolvedUserId) {
     return null;
   }
 

--- a/src/components/list-button.tsx
+++ b/src/components/list-button.tsx
@@ -126,19 +126,15 @@ function ListMenuItems({
   ));
 }
 
-// Prefer the server-provided id, but fall back to the client session so cards
-// rendered from prerendered (cached) lists still get the button once hydrated.
-function useResolvedUserId(userId?: string) {
-  const { data: session } = useSession();
-  return userId ?? session?.user?.id;
-}
-
-export function ListButton({ mediaId, mediaType, userId, showWatchlist = true }: ListButtonProps) {
+function ListButtonInner({
+  mediaId,
+  mediaType,
+  showWatchlist = true,
+}: Omit<ListButtonProps, 'userId'>) {
   const [isOpen, setIsOpen] = useState(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isPending, setIsPending] = useState(false);
   const queryClient = useQueryClient();
-  const resolvedUserId = useResolvedUserId(userId);
 
   const { data: lists = [], isLoading: isLoadingLists } = useQuery({
     queryKey: queryKeys.lists.withStatus(mediaId, mediaType),
@@ -154,9 +150,6 @@ export function ListButton({ mediaId, mediaType, userId, showWatchlist = true }:
     enabled: isOpen && showWatchlist,
   });
 
-  if (!resolvedUserId) {
-    return null;
-  }
 
   async function handleToggleList(listId: string, hasItem: boolean) {
     const listName = findListName(lists, listId);
@@ -250,4 +243,25 @@ export function ListButton({ mediaId, mediaType, userId, showWatchlist = true }:
       />
     </>
   );
+}
+
+// Fallback for cards rendered from prerendered (cached) lists that have no
+// server-provided userId: resolve the signed-in user from the client session.
+// Only this path subscribes to the session, so server-id callers stay cheap.
+function SessionListButton(props: Omit<ListButtonProps, 'userId'>) {
+  const { data: session } = useSession();
+
+  if (!session?.user?.id) {
+    return null;
+  }
+
+  return <ListButtonInner {...props} />;
+}
+
+export function ListButton({ userId, ...props }: ListButtonProps) {
+  if (userId) {
+    return <ListButtonInner {...props} />;
+  }
+
+  return <SessionListButton {...props} />;
 }

--- a/src/components/media-list.tsx
+++ b/src/components/media-list.tsx
@@ -1,12 +1,10 @@
 import ItemCard from '@/components/item-card';
-import { getUser } from '@/lib/auth-server';
 import { Movie } from '@/types/movie';
 import { TvShow } from '@/types/tv-show';
 
 type MediaItem = Movie | TvShow;
 
 type MediaListProps = {
-  fetchUserItems?: () => Promise<MediaItem[]>;
   fetchItems: () => Promise<MediaItem[]>;
   type: 'movie' | 'tv';
 };
@@ -14,24 +12,20 @@ type MediaListProps = {
 /**
  * Generic component that displays a list of media items (movies or TV shows) as resource cards.
  *
- * Fetches either personalized or general items depending on user authentication, and renders each as an {@link ItemCard}.
+ * Renders only cached, request-independent data so the surrounding Suspense boundary can be
+ * prerendered rather than server-streamed. Per-user state (the list/watchlist button) is resolved
+ * client-side inside {@link ItemCard}'s ListButton via the auth session, so the markup stays cacheable.
+ * Streaming this content instead crashes hydration under cacheComponents on next@16.2.9 — see the
+ * blank-landing-page bug.
  *
- * @param fetchUserItems - Optional function to fetch user-specific items. If not provided, fetchItems will be used for all users.
- * @param fetchItems - Function to fetch general items (used when user is not logged in or when fetchUserItems is not provided).
+ * @param fetchItems - Function to fetch the (cached) items to display.
  * @param type - The media type, either 'movie' or 'tv'.
  * @returns An array of {@link ItemCard} elements representing the media items.
  */
-export default async function MediaList({ fetchUserItems, fetchItems, type }: MediaListProps) {
-  const user = await getUser();
-  const items = user && fetchUserItems ? await fetchUserItems() : await fetchItems();
+export default async function MediaList({ fetchItems, type }: MediaListProps) {
+  const items = await fetchItems();
 
   return items.map((item) => (
-    <ItemCard
-      className="max-w-[150px]"
-      key={item.id}
-      resource={item}
-      type={type}
-      userId={user?.id}
-    />
+    <ItemCard className="max-w-[150px]" key={item.id} resource={item} type={type} />
   ));
 }

--- a/src/lib/movies.ts
+++ b/src/lib/movies.ts
@@ -172,47 +172,6 @@ export async function fetchUpcomingMovies() {
 }
 
 /**
- * Fetches movies currently playing in theaters for the user's region, using a fallback if the region cannot be determined.
- *
- * @returns An array of movies now playing in the user's region
- */
-export async function fetchUserNowPlayingMovies() {
-  const userRegion = await getUserRegionWithFallback();
-
-  const movies = await tmdbFetch<MovieResponse>('/movie/now_playing', {
-    searchParams: { region: userRegion },
-    errorMessage: 'Failed loading now playing movies',
-  });
-  return movies.results;
-}
-
-/**
- * Retrieves upcoming movies for the user's region, excluding those currently playing in theaters.
- *
- * @returns An array of upcoming movies not currently in theaters for the user's region.
- *
- * @throws {Error} If the request for upcoming movies fails.
- */
-export async function fetchUserUpcomingMovies() {
-  const userRegion = await getUserRegionWithFallback();
-
-  const [upcomingMovies, nowPlayingMovies] = await Promise.all([
-    tmdbFetch<MovieResponse>('/movie/upcoming', {
-      searchParams: { region: userRegion },
-      errorMessage: 'Failed loading upcoming movies',
-    }),
-    fetchUserNowPlayingMovies(),
-  ]);
-
-  const nowPlayingIds = new Set(nowPlayingMovies.map((movie) => movie.id));
-  const filteredUpcomingMovies = upcomingMovies.results.filter(
-    (movie) => !nowPlayingIds.has(movie.id),
-  );
-
-  return filteredUpcomingMovies;
-}
-
-/**
  * Retrieves a list of top-rated movies from the Movie Database API for the SE region.
  *
  * Filters out adult content and videos, sorts results by highest vote average, and returns the resulting movie array.
@@ -228,23 +187,6 @@ export async function fetchTopRatedMovies() {
 
   const movies = await tmdbFetch<MovieResponse>('/movie/top_rated', {
     searchParams: { region: DEFAULT_REGION },
-    errorMessage: 'Failed loading top rated movies',
-  });
-  return movies.results;
-}
-
-/**
- * Fetches top-rated movies for the user's region, using a fallback if the region cannot be determined.
- *
- * @returns An array of top-rated movies for the user's region.
- *
- * @throws {Error} If the request to fetch top-rated movies fails.
- */
-export async function fetchUserTopRatedMovies() {
-  const userRegion = await getUserRegionWithFallback();
-
-  const movies = await tmdbFetch<MovieResponse>('/movie/top_rated', {
-    searchParams: { region: userRegion },
     errorMessage: 'Failed loading top rated movies',
   });
   return movies.results;

--- a/src/lib/tv-shows.ts
+++ b/src/lib/tv-shows.ts
@@ -195,23 +195,6 @@ export async function fetchTopRatedTvShows() {
 }
 
 /**
- * Fetches the top-rated TV shows for the user's region, using a fallback region if necessary.
- *
- * @returns An array of top-rated TV shows for the determined user region.
- *
- * @throws {Error} If the request to fetch top-rated TV shows fails.
- */
-export async function fetchUserTopRatedTvShows() {
-  const userRegion = await getUserRegionWithFallback();
-
-  const tvShows = await tmdbFetch<TvResponse>('/tv/top_rated', {
-    searchParams: { region: userRegion, include_adult: 'false' },
-    errorMessage: 'Failed loading top rated TV shows',
-  });
-  return tvShows.results;
-}
-
-/**
  * Fetches TV shows that are currently airing in the default region.
  *
  * @returns An array of TV show objects currently on the air in the default region.
@@ -231,25 +214,6 @@ export async function fetchOnTheAirTvShows() {
 }
 
 /**
- * Fetches TV shows currently airing in the user's region.
- *
- * Determines the user's region with fallback and retrieves a list of TV shows that are currently on the air for that region.
- *
- * @returns An array of TV shows currently airing in the user's region.
- *
- * @throws {Error} If the request to fetch on-the-air TV shows fails.
- */
-export async function fetchUserOnTheAirTvShows() {
-  const userRegion = await getUserRegionWithFallback();
-
-  const tvShows = await tmdbFetch<TvResponse>('/tv/on_the_air', {
-    searchParams: { region: userRegion },
-    errorMessage: 'Failed loading on the air TV shows',
-  });
-  return tvShows.results;
-}
-
-/**
  * Fetches a list of popular TV shows for the default region.
  *
  * @returns An array of popular TV shows.
@@ -263,23 +227,6 @@ export async function fetchPopularTvShows() {
 
   const tvShows = await tmdbFetch<TvResponse>('/tv/popular', {
     searchParams: { region: DEFAULT_REGION },
-    errorMessage: 'Failed loading popular TV shows',
-  });
-  return tvShows.results;
-}
-
-/**
- * Fetches popular TV shows for the user's region, using a fallback if the region cannot be determined.
- *
- * @returns An array of popular TV shows available in the user's region.
- *
- * @throws If the request to fetch popular TV shows fails.
- */
-export async function fetchUserPopularTvShows() {
-  const userRegion = await getUserRegionWithFallback();
-
-  const tvShows = await tmdbFetch<TvResponse>('/tv/popular', {
-    searchParams: { region: userRegion },
     errorMessage: 'Failed loading popular TV shows',
   });
   return tvShows.results;


### PR DESCRIPTION
The homepage went blank on reload in production: the server returned full HTML, then hydration threw "insertBefore: new child contains the parent" and React unmounted the whole tree. Root cause is a cacheComponents (PPR) streaming-hydration bug in next@16.2.9 + react@19.2.7 — content rendered inside a dynamic, server-streamed Suspense boundary crashes on hydration, while the same markup prerendered hydrates fine.

Every homepage slider streamed because MediaList called getUser() (a dynamic hole); Trending was cached and prerendered, so it never crashed. Make the sliders prerender too:

- MediaList: drop getUser()/fetchUserItems, render only cached fetchItems so each Suspense boundary prerenders instead of streaming.
- ListButton: resolve the user from the client useSession() hook instead of a server userId prop, so logged-in users keep the button on cached cards.
- Remove the now-dead fetchUser* homepage fetchers; collapse the six repeated homepage sections into one config-driven MediaSection helper.

Tradeoff: landing-page lists use the default region for everyone; per-region personalization elsewhere (e.g. /discover) is unaffected. Revisit once on a Next >=16.3 stable, which fixes the bug upstream.