### PR TITLE
💄 cap poster width on mobile

### DIFF
--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -10,14 +10,16 @@ function Poster({ poster_path, title }: PosterProps) {
   return (
     <div className="lg:col-span-4">
       {poster_path ? (
-        <Imgproxy
-          className="aspect-2/3 w-full max-w-64 rounded-lg border shadow-2xl sm:mx-0 lg:max-w-full"
-          src={poster_path}
-          alt={`Poster image of ${title}`}
-          width={500}
-          height={750}
-          priority
-        />
+        <div className="max-w-64 lg:max-w-full">
+          <Imgproxy
+            className="aspect-2/3 w-full rounded-lg border shadow-2xl"
+            src={poster_path}
+            alt={`Poster image of ${title}`}
+            width={500}
+            height={750}
+            priority
+          />
+        </div>
       ) : (
         <div className="mx-auto flex aspect-2/3 w-full max-w-md items-center justify-center rounded-lg bg-zinc-800 shadow-2xl">
           <div className="text-center text-zinc-400">


### PR DESCRIPTION
## Summary
The movie/TV detail poster stretched to full viewport width on mobile, which looked odd. The `max-w-64` cap on the image never took effect: the `Imgproxy` component appends a CSS-module class with `max-width: 100%`, and unlayered CSS-module rules always beat Tailwind v4's `@layer utilities` in the cascade.

## Fix
Move the width cap to a wrapper `div` around the image in `Poster`, where nothing competes with it. The image keeps `w-full` + aspect ratio inside the wrapper. Applies to both the movie and TV detail pages.

## Notes
Any other component relying on `max-w-*`/`h-*` utilities directly on an `Imgproxy` image has the same latent conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)