### PR TITLE
♻️ convert read-only fetchers to server-only modules

### DIFF
--- a/src/lib/discover-client.ts
+++ b/src/lib/discover-client.ts
@@ -1,3 +1,7 @@
+// The single client-callable entry point for discover queries; the underlying
+// fetchers in movies.ts/tv-shows.ts are server-only.
+'use server';
+
 import { fetchDiscoverMovies } from '@/lib/movies';
 import { fetchDiscoverTvShows } from '@/lib/tv-shows';
 import type { Movie } from '@/types/movie';

--- a/src/lib/imdb.ts
+++ b/src/lib/imdb.ts
@@ -1,7 +1,4 @@
-// TODO: convert to a server-only module — these are read-only fetchers, and
-// 'use server' exposes them as publicly callable actions. Fix repo-wide
-// (movies.ts/tv-shows.ts share the pattern) in a follow-up PR after this merges.
-'use server';
+import 'server-only';
 
 import { eq } from 'drizzle-orm';
 import { cacheLife, cacheTag } from 'next/cache';

--- a/src/lib/media-info.ts
+++ b/src/lib/media-info.ts
@@ -1,7 +1,4 @@
-// TODO: convert to a server-only module — these are read-only fetchers, and
-// 'use server' exposes them as publicly callable actions. Fix repo-wide
-// (movies.ts/tv-shows.ts share the pattern) in a follow-up PR after this merges.
-'use server';
+import 'server-only';
 
 import { cacheLife, cacheTag } from 'next/cache';
 

--- a/src/lib/movies.ts
+++ b/src/lib/movies.ts
@@ -1,4 +1,4 @@
-'use server';
+import 'server-only';
 
 import { cacheLife, cacheTag } from 'next/cache';
 

--- a/src/lib/tv-shows.ts
+++ b/src/lib/tv-shows.ts
@@ -1,4 +1,4 @@
-'use server';
+import 'server-only';
 
 import { cacheLife, cacheTag } from 'next/cache';
 


### PR DESCRIPTION
## Summary
- Resolves the TODOs left in #257: `imdb.ts`, `media-info.ts`, `movies.ts`, and `tv-shows.ts` were read-only fetcher modules marked `'use server'`, which exposed every export as a publicly callable server action. They now `import 'server-only'` instead.
- `discover-client.ts` ran in the browser and called `fetchDiscoverMovies`/`fetchDiscoverTvShows` as actions, so it becomes the single deliberate `'use server'` entry point (`getDiscoverMedia`) while the underlying fetchers stay server-only.
- `search.ts`, `home-media.ts`, `lists.ts`, and `system-list-queries.ts` intentionally remain `'use server'` — client components call their exports directly via react-query.

## Testing
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (247 passed), `pnpm fallow` all pass
- `pnpm build` passes, verifying the server-only boundary holds (it caught the discover-client case during development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)