### PR TITLE
🧱 make preview postgres serverless with low limits

### DIFF
--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -18,15 +18,30 @@ function currentGitBranch() {
 export default defineRailway((ctx) => {
   const prod = ctx.isEnvironment("production");
 
-  // Declared in every environment (production included, where it sits unused
-  // and asleep) because Railway IaC seeds database credentials only when the
-  // service is new project-wide: PR environments fork production, so prod must
-  // hold a fully-configured instance for preview databases to inherit. The
-  // name is postgres-db (not postgres) because the original hollow "postgres"
-  // service still exists project-level for older PR environments; delete it
-  // once those PRs close. Production keeps the external DB — see the movies
-  // service's DATABASE_URL below.
-  const db = postgres("postgres-db");
+  // Railway provisions this volume with the managed Postgres; declare it so
+  // plans don't try to delete it or shrink it.
+  const dbVolume = volume("postgres-db-volume", {
+    region: "europe-west4-drams3a",
+    sizeMB: 5000,
+    allowOnlineResize: true,
+    alerts: { usage: { "80": {}, "95": {}, "100": {} } },
+  });
+
+  // Managed Postgres for preview databases, declared in every environment
+  // (production included, where it sits unused and asleep — the app there
+  // keeps the external DB) so PR environments fork a fully-configured
+  // instance. The deploy options rely on patches/railway.patch: upstream
+  // drops deploy config for database nodes, which would otherwise unset
+  // these on every apply. The old hollow "postgres" service still exists
+  // project-level for older PR environments; delete it once those PRs close.
+  const db = postgres("postgres-db", {
+    deploy: {
+      // Sleeps when idle (a connection wakes it), so the unused prod instance
+      // and quiet previews cost next to nothing.
+      sleepApplication: true,
+      limitOverride: { containers: { cpu: 1, memoryBytes: 500000000 } },
+    },
+  });
 
   const imgproxyHRto = service("imgproxy-HRto", {
     source: image("darthsim/imgproxy:v3.18.2"),
@@ -101,16 +116,6 @@ export default defineRailway((ctx) => {
         },
       })
     : null;
-
-  // Railway provisions this volume with the managed Postgres; declare it so
-  // plans don't try to delete it or shrink it. The `<db name>-volume` naming
-  // pairs it with the postgres-db service.
-  const dbVolume = volume("postgres-db-volume", {
-    region: "europe-west4-drams3a",
-    sizeMB: 5000,
-    allowOnlineResize: true,
-    alerts: { usage: { "80": {}, "95": {}, "100": {} } },
-  });
 
   return project("movies", {
     // imdbIngest exists only in prod; filter the inactive entry out instead of

--- a/patches/railway.patch
+++ b/patches/railway.patch
@@ -1,0 +1,55 @@
+diff --git a/dist/iac/index.js b/dist/iac/index.js
+index 6b602cf39512b97157a3e21b3fec5c41b9c4ed05..1650527c623e48f5eeb29886cf8b5f577581ba40 100644
+--- a/dist/iac/index.js
++++ b/dist/iac/index.js
+@@ -239,9 +239,11 @@ function databaseRegion(database2) {
+   return regions[0]?.[0];
+ }
+ function databaseDeploy(database2, requiredMountPath) {
++  const { multiRegionConfig, ...deployRest } = database2.deploy ?? {};
+   return {
+     requiredMountPath,
+-    ...database2.deploy?.multiRegionConfig ? { multiRegionConfig: database2.deploy.multiRegionConfig } : {}
++    ...deployRest,
++    ...multiRegionConfig ? { multiRegionConfig } : {}
+   };
+ }
+ function databaseToEnvironmentConfig(database2, options) {
+@@ -1326,7 +1328,12 @@ function database(name, engine, options) {
+     output,
+     defaultMountPath: options.defaultMountPath,
+     source: image(options.image),
+-    ...options.region ? { deploy: { multiRegionConfig: { [options.region]: { numReplicas: 1 } } } } : {}
++    ...options.deploy || options.region ? {
++      deploy: {
++        ...options.deploy ?? {},
++        ...options.region ? { multiRegionConfig: { [options.region]: { numReplicas: 1 } } } : {}
++      }
++    } : {}
+   };
+   return withVariableRefs(node);
+ }
+diff --git a/dist/index-qc8SqGnG.d.cts b/dist/index-qc8SqGnG.d.cts
+index 9123cd403d2d49888269ac76602f319aeb0d059c..b27bb6c3c7a9604504e920be33f06b8b14d2db0b 100644
+--- a/dist/index-qc8SqGnG.d.cts
++++ b/dist/index-qc8SqGnG.d.cts
+@@ -620,6 +620,7 @@ declare function fn<const Env extends Record<string, string | VariableConfig | V
+ }): ReferencableServiceNode<RailwayProvidedVariable | Extract<keyof Env, string>>;
+ interface DatabaseConfig {
+     region?: string;
++    deploy?: DeployConfig;
+ }
+ declare function postgres(name: string, config?: DatabaseConfig): ReferencableDatabaseNode<"postgres">;
+ declare function mysql(name: string, config?: DatabaseConfig): ReferencableDatabaseNode<"mysql">;
+diff --git a/dist/index-qc8SqGnG.d.ts b/dist/index-qc8SqGnG.d.ts
+index 9123cd403d2d49888269ac76602f319aeb0d059c..b27bb6c3c7a9604504e920be33f06b8b14d2db0b 100644
+--- a/dist/index-qc8SqGnG.d.ts
++++ b/dist/index-qc8SqGnG.d.ts
+@@ -620,6 +620,7 @@ declare function fn<const Env extends Record<string, string | VariableConfig | V
+ }): ReferencableServiceNode<RailwayProvidedVariable | Extract<keyof Env, string>>;
+ interface DatabaseConfig {
+     region?: string;
++    deploy?: DeployConfig;
+ }
+ declare function postgres(name: string, config?: DatabaseConfig): ReferencableDatabaseNode<"postgres">;
+ declare function mysql(name: string, config?: DatabaseConfig): ReferencableDatabaseNode<"mysql">;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  railway: 3e00584f75cd5ea161492b22760882fe70893834901cc439f49b6a12cf580fed
+
 importers:
 
   .:
@@ -146,7 +149,7 @@ importers:
         version: 0.24.0
       railway:
         specifier: ^3.5.2
-        version: 3.5.2
+        version: 3.5.2(patch_hash=3e00584f75cd5ea161492b22760882fe70893834901cc439f49b6a12cf580fed)
       shadcn:
         specifier: ^4.13.0
         version: 4.13.0(typescript@6.0.3)
@@ -6759,7 +6762,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  railway@3.5.2:
+  railway@3.5.2(patch_hash=3e00584f75cd5ea161492b22760882fe70893834901cc439f49b6a12cf580fed):
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
       graphql: 16.14.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ allowBuilds:
   msw: true
   protobufjs: true
   sharp: true
+patchedDependencies:
+  railway: patches/railway.patch


### PR DESCRIPTION
## Summary
- `postgres-db` now declares **App Sleep** and **1 vCPU / 0.5 GB** resource limits in `.railway/railway.ts` — the idle prod instance and quiet preview databases scale to zero between connections.
- Upstream `railway` drops `deploy` config for database nodes, which meant these settings could not be declared (and any out-of-band setting was **unset on every apply**). `patches/railway.patch` passes deploy options through `database()` and `databaseDeploy()`. Worth upstreaming.
- A `service()` declaration was tried first but can't work: the live side re-reads postgres-image services as database nodes, so plans never converge (create/delete oscillation).

## State
- Already applied to production (with your approvals along the way): the live `postgres-db` runs the postgres-ssl image with sleep on, low limits, and freshly seeded credentials (it was recreated during the service()-experiment churn — it held no data). Plan against production is clean.
- Note: prod `postgres-db` has a new service ID; PR environments forked from now on inherit the sleep + limits.

## Testing
- `railway config plan` (production): ✓ already up to date — the settings are now maintained, not reverted
- `pnpm lint`, `tsc --noEmit`, `pnpm test` (280 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)