### PR TITLE
📝 update readme to match the current app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ A web app for exploring movies and TV shows and keeping track of what you watch,
 ```bash
 pnpm install
 cp .env.example .env   # fill in secrets — src/env.ts is the source of truth
-pnpm dev               # boots local Postgres + imgproxy via Docker, then next dev
-pnpm db:push           # apply the schema once the database is up
+pnpm dev:docker:up     # start local Postgres + imgproxy via Docker
+pnpm db:push           # apply the schema
+pnpm dev               # dev server (starts the Docker services if needed)
 ```
 
 Open [http://localhost:3000](http://localhost:3000). See [CONTRIBUTING.md](./CONTRIBUTING.md) for prerequisites, environment details, and conventions.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,78 @@
 # Movies App
 
-A modern web application for exploring and managing movies, built with Next.js 15 and TypeScript.
+A web app for exploring movies and TV shows and keeping track of what you watch, built with Next.js and TypeScript on top of the TMDB API.
+
+## Features
+
+- Browse trending, now playing, upcoming, and top rated movies and TV shows
+- Discover by genre with sorting, watch-provider and runtime filters
+- Search across movies, TV shows, and people (with a command palette)
+- Detail pages with trailers, cast, recommendations, reviews, age certifications, watch providers, and IMDb ratings
+- Person pages with filmographies
+- Watchlist, watched tracking, and custom lists with drag-and-drop reordering
+- Authentication with passkeys, Discord, and GitHub (Better Auth)
+- Dark mode and responsive UI
 
 ## Road map
 
 - [x] Movie trailers
 - [x] Person pages
 - [x] Custom movie lists
-- [ ] Watched movies tracking
+- [x] Watched movies tracking
 - [ ] Personal ratings
 - [ ] Social features
 
-## Features
+## Tech stack
 
-- Browse movie library
-- Search for movies
-- View detailed information about each movie
-- User authentication
-- Dark mode support
-- Responsive design with modern UI components
-
-## Tech Stack
-
-- **Framework**: Next.js 15 (Canary) with App Router
-- **Language**: TypeScript 5.8
+- **Framework**: Next.js 16 (App Router, cache components) with React 19
+- **Language**: TypeScript
 - **Database**: PostgreSQL with Drizzle ORM
-- **Styling**: Tailwind CSS 4.1 with Radix UI components
-- **Package Manager**: PNPM 10
-- **Authentication**: Better Auth
-- **Analytics**: Vercel Analytics & PostHog
-- **Development Tools**:
-  - Oxc (oxlint)
-  - Turbopack for development
+- **Styling**: Tailwind CSS 4 with Base UI components
+- **Auth**: Better Auth (passkeys, Discord, GitHub)
+- **Images**: imgproxy for signed, resized poster images
+- **Analytics**: PostHog
+- **Tooling**: pnpm, oxlint/oxfmt, Vitest, Playwright, fallow
+- **Infrastructure**: Railway (app, imgproxy, daily IMDb ratings ingest cron, per-PR preview environments with their own Postgres), configured as code in `.railway/railway.ts`
 
-## Getting Started
-
-1. Clone the project:
-
-```bash
-git clone <your-repo-url>
-cd movies
-```
-
-2. Install dependencies:
+## Getting started
 
 ```bash
 pnpm install
+cp .env.example .env   # fill in secrets — src/env.ts is the source of truth
+pnpm dev               # boots local Postgres + imgproxy via Docker, then next dev
+pnpm db:push           # apply the schema once the database is up
 ```
 
-3. Set up environment variables:
-   - Copy `.env.example` to `.env`
-   - Update the database URL and other required variables
+Open [http://localhost:3000](http://localhost:3000). See [CONTRIBUTING.md](./CONTRIBUTING.md) for prerequisites, environment details, and conventions.
 
-4. Set up the database:
+## Scripts
 
-```bash
-pnpm db:generate  # Generate migrations
-pnpm db:push     # Push changes to database
-```
+Run `pnpm run` for the authoritative list. The most used:
 
-5. Start the development server:
+- `pnpm dev` — dev server (starts Docker services first)
+- `pnpm lint` / `pnpm format` — lint and format
+- `pnpm test` — unit tests (Vitest)
+- `pnpm e2e` — end-to-end tests (Playwright)
+- `pnpm fallow` — audit changed files (dead code, complexity, duplication)
+- `pnpm db:generate` / `pnpm db:migrate` / `pnpm db:push` / `pnpm db:studio` — Drizzle
+- `pnpm ingest:imdb` — populate IMDb ratings locally (optional, ~1.5M rows)
 
-```bash
-pnpm dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
-
-## Project Structure
+## Project structure
 
 ```
 movies/
 ├── src/
 │   ├── app/          # Next.js app router pages and layouts
 │   ├── components/   # Reusable React components
-│   ├── db/          # Database schema and configurations
-│   ├── hooks/       # Custom React hooks
-│   ├── lib/         # Utility functions and shared logic
-│   ├── providers/   # React context providers
-│   ├── types/       # TypeScript type definitions
-│   └── icons/       # SVG icons and assets
-├── public/          # Static assets
-└── drizzle/         # Database migrations and configuration
+│   ├── db/           # Database schema
+│   ├── hooks/        # Custom React hooks
+│   ├── lib/          # Data fetchers, server actions, and shared logic
+│   ├── providers/    # React context providers
+│   ├── types/        # TypeScript type definitions
+│   └── icons/        # SVG icons
+├── e2e/              # Playwright end-to-end tests
+├── drizzle/          # Database migrations
+├── scripts/          # Maintenance scripts (IMDb ingest, seeding)
+├── .railway/         # Railway infrastructure as code
+└── public/           # Static assets
 ```
-
-## Available Scripts
-
-- `pnpm dev` - Start development server with Turbopack
-- `pnpm build` - Build for production
-- `pnpm start` - Start production server
-- `pnpm lint` - Run Oxc linting
-- `pnpm format` - Apply Oxc autofixes
-- `pnpm db:generate` - Generate database migrations
-- `pnpm db:push` - Push database changes
-- `pnpm db:studio` - Open Drizzle Studio
-
-## Development
-
-The project uses several modern development tools and practices:
-
-- Turbopack for fast development builds
-- Strict TypeScript configuration
-- Oxc for linting and autofix
-- Tailwind CSS for styling with custom components
-- Drizzle ORM for type-safe database operations


### PR DESCRIPTION
## Summary
- Rewrites the README to reflect the current app: TV shows, discover filters, command-palette search, lists/watched tracking, passkey/Discord/GitHub auth, IMDb ratings
- Tech stack corrected to Next.js 16 / React 19 / Tailwind 4 / Base UI, plus imgproxy, PostHog, and the Railway infrastructure (IMDb ingest cron, per-PR preview environments)
- Getting started matches the actual flow (`pnpm dev` boots Docker services) and defers to CONTRIBUTING.md
- Script list matches package.json (`e2e`, `fallow`, `ingest:imdb`, drizzle commands); roadmap checks off watched tracking
- Project structure adds `e2e/`, `scripts/`, `.railway/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)