### PR TITLE
🧱 declare imdb-ingest in every environment

### DIFF
--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -5,6 +5,10 @@ import { defineRailway, github, image, postgres, preserve, project, service, vol
 const APP_DOMAIN = "movies.emmut.space";
 const CDN_DOMAIN = "cdn.emmut.space";
 
+// Railway sizes memory in decimal bytes (1 GB = 1_000_000_000).
+const MB_IN_BYTES = 1_000_000;
+const GB_IN_BYTES = 1_000 * MB_IN_BYTES;
+
 function currentGitBranch() {
   // On a detached HEAD there is no current branch — provide it via RAILWAY_IAC_BRANCH instead.
   const branch =
@@ -22,7 +26,7 @@ export default defineRailway((ctx) => {
   // plans don't try to delete it or shrink it.
   const dbVolume = volume("postgres-db-volume", {
     region: "europe-west4-drams3a",
-    sizeMB: 5000,
+    sizeMB: 5_000,
     allowOnlineResize: true,
     alerts: { usage: { "80": {}, "95": {}, "100": {} } },
   });
@@ -39,7 +43,7 @@ export default defineRailway((ctx) => {
       // Sleeps when idle (a connection wakes it), so the unused prod instance
       // and quiet previews cost next to nothing.
       sleepApplication: true,
-      limitOverride: { containers: { cpu: 1, memoryBytes: 500000000 } },
+      limitOverride: { containers: { cpu: 1, memoryBytes: 500 * MB_IN_BYTES } },
     },
   });
 
@@ -67,7 +71,7 @@ export default defineRailway((ctx) => {
     // its prompt renderer while the deploy still reports success, leaving a
     // partial schema and an empty migration journal behind.
     preDeploy: "pnpm db:migrate",
-    deploy: { limitOverride: { containers: { cpu: 2, memoryBytes: 1000000000 } }, sleepApplication: true },
+    deploy: { limitOverride: { containers: { cpu: 2, memoryBytes: 1 * GB_IN_BYTES } }, sleepApplication: true },
     domains: prod ? [APP_DOMAIN] : [],
     env: {
       BETTER_AUTH_SECRET: preserve(),
@@ -110,7 +114,7 @@ export default defineRailway((ctx) => {
       restartPolicyType: "NEVER",
       // Streaming ingest with 5k-row batches and a single pg connection —
       // stays well under half a GB and one core.
-      limitOverride: { containers: { cpu: 1, memoryBytes: 500000000 } },
+      limitOverride: { containers: { cpu: 1, memoryBytes: 500 * MB_IN_BYTES } },
     },
     env: {
       // Production ingests into the external DB; previews into their forked

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -93,33 +93,33 @@ export default defineRailway((ctx) => {
   });
 
   // Daily cron that ingests IMDb's ratings dataset into the imdb_ratings
-  // table. Prod-only: preview databases just show the card as hidden, and a
-  // dev can run `pnpm ingest:imdb` manually when needed. IMDb refreshes the
-  // datasets early UTC, so run shortly after.
-  const imdbIngest = prod
-    ? service("imdb-ingest", {
-        source: github("emmut/movies"),
-        // The cron only needs dependencies + tsx; Railpack's default
-        // `pnpm run build` would run `next build`, which fails env validation
-        // since this service only has DATABASE_URL.
-        build: { buildCommand: "echo 'skipping app build — cron runs tsx directly'" },
-        deploy: {
-          startCommand: "pnpm tsx scripts/ingest-imdb-ratings.ts",
-          cronSchedule: "30 5 * * *",
-          restartPolicyType: "NEVER",
-          // Streaming ingest with 5k-row batches and a single pg connection —
-          // stays well under half a GB and one core.
-          limitOverride: { containers: { cpu: 1, memoryBytes: 500000000 } },
-        },
-        env: {
-          DATABASE_URL: preserve(),
-        },
-      })
-    : null;
+  // table. Declared in every environment: PR environments fork production
+  // including this service, and deleting it there cancelled the forked
+  // deployment mid-flight, which Railway reported as a failed PR check.
+  // Previews ingest into their own postgres instead (and get real IMDb data);
+  // IMDb refreshes the datasets early UTC, so run shortly after.
+  const imdbIngest = service("imdb-ingest", {
+    source: github("emmut/movies"),
+    // The cron only needs dependencies + tsx; Railpack's default
+    // `pnpm run build` would run `next build`, which fails env validation
+    // since this service only has DATABASE_URL.
+    build: { buildCommand: "echo 'skipping app build — cron runs tsx directly'" },
+    deploy: {
+      startCommand: "pnpm tsx scripts/ingest-imdb-ratings.ts",
+      cronSchedule: "30 5 * * *",
+      restartPolicyType: "NEVER",
+      // Streaming ingest with 5k-row batches and a single pg connection —
+      // stays well under half a GB and one core.
+      limitOverride: { containers: { cpu: 1, memoryBytes: 500000000 } },
+    },
+    env: {
+      // Production ingests into the external DB; previews into their forked
+      // postgres-db.
+      DATABASE_URL: prod ? preserve() : db.env.DATABASE_URL,
+    },
+  });
 
   return project("movies", {
-    // imdbIngest exists only in prod; filter the inactive entry out instead of
-    // asserting with `!`.
-    resources: [movies, imgproxyHRto, db, dbVolume, imdbIngest].filter((r) => r !== null),
+    resources: [movies, imgproxyHRto, db, dbVolume, imdbIngest],
   });
 });


### PR DESCRIPTION
## Summary
- Every new PR showed a red `movies - imdb-ingest` check ("Deployment cancelled"): the PR environment forks production including imdb-ingest and starts deploying it, then the infra apply deleted it (it was declared prod-only), cancelling the deployment mid-flight.
- Declaring the cron in every environment fixes this: nothing gets deleted, the forked deployment completes (the build is a no-op echo), and previews ingest IMDb ratings into their own `postgres-db` on the daily schedule — so preview environments now show real IMDb rating cards too.
- Race note: a forked instance briefly carries prod's `DATABASE_URL` until the apply rewrites it, but cron services only run on schedule (05:30 UTC), long after the apply lands.

## Testing
- `railway config plan` against production: no changes (the prod declaration is identical)
- `tsc --noEmit` and `pnpm lint` pass
- This PR's own environment is the end-to-end test: the `movies - imdb-ingest` check should now be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)