### PR TITLE
🐛 clip the home loading skeleton to one viewport

### DIFF
--- a/src/app/(home)/loading.tsx
+++ b/src/app/(home)/loading.tsx
@@ -10,10 +10,16 @@ import { HOME_SECTIONS, MediaSectionHeader, TrendingHeader } from './sections';
  * Renders the exact same shell as the page — real section headings in the same
  * order, with skeleton sliders in place of the async media rows — so the layout
  * doesn't shift when the real content streams in.
+ *
+ * All sections stay in the DOM (so the section count matches the page and
+ * nothing jumps on swap), but the stack is clipped to roughly one viewport.
+ * A skeleton taller than the viewport keeps the previous route's scroll offset
+ * on a client navigation — Next only resets scroll once real content arrives —
+ * which shows it "chopped off"; a short one lets the browser clamp to the top.
  */
 export default function Loading() {
   return (
-    <div className="space-y-8">
+    <div className="max-h-[80dvh] space-y-8 overflow-hidden">
       <section className="space-y-4">
         <TrendingHeader />
 


### PR DESCRIPTION
## What & why

Follow-up to #266. The homepage `loading.tsx` stacks the trending row plus six media sections (~2400px). Navigating to home **while scrolled down** kept the previous route's scroll offset — Next only resets scroll once the real content arrives — so the tall skeleton showed up "chopped off" (scrolled ~1500px down) for a moment.

## Change

Clip the skeleton stack to ~one viewport with `max-h-[80dvh] overflow-hidden`. All six sections stay in the DOM, so the section count still matches the page and nothing jumps on swap; the shorter document just lets the browser clamp the scroll back to the top. This is the same short-skeleton approach used for the grid pages in #266 (discover, search, lists, watchlist/watched).

## Verification

- Repro (discover scrolled to bottom → click Home): previously landed at ~y=1500 mid-skeleton; now lands at **y=0**. Skeleton document height dropped from ~2400px to ~1026px.
- Screenshotted the clipped skeleton — trending + first sections render cleanly, sliders intact.
- `pnpm lint`, `tsc --noEmit`, `pnpm test` (280), `pnpm fallow` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)