### PR TITLE
🐛 fix discover pagination scroll on mobile Safari + WebKit e2e

### DIFF
--- a/e2e/discover-pagination-scroll.spec.ts
+++ b/e2e/discover-pagination-scroll.spec.ts
@@ -1,0 +1,102 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Regression (mobile Safari): tapping a pagination link left the viewport
+// partway up the page instead of at the top of the results. Paginating is a
+// soft navigation, and WebKit fires its own scroll a few hundred ms after the
+// `pushState`, clobbering the scroll fired on the click.
+//
+// This runs under the `mobile-safari` project (WebKit + an iPhone viewport) —
+// the engine and form factor where the bug reproduces; Chromium does not
+// exhibit it. The discover data is deliberately delayed so the skeleton →
+// results swap lands mid-scroll, the timing that lost the scroll.
+//
+// Invariant: after paginating from a scrolled-down position, the viewport
+// settles at the top of `#content-container` (its first item, minus the
+// `scroll-m-5` gap), not at the page top.
+
+const SCROLL_MARGIN = 20; // scroll-m-5 on #content-container (1.25rem)
+
+/**
+ * Polls `window.scrollY` until it holds steady, so we measure where the scroll
+ * comes to rest rather than a frame mid-animation (or mid-cancellation).
+ *
+ * @param page - The Playwright page.
+ */
+async function settledScrollY(page: Page): Promise<number> {
+  let stableReads = 0;
+  let last = Number.NaN;
+
+  for (let i = 0; i < 60; i++) {
+    const y = await page.evaluate(() => Math.round(window.scrollY));
+    stableReads = y === last ? stableReads + 1 : 0;
+    // Steady across ~500ms of polling counts as settled.
+    if (stableReads >= 4) return y;
+    last = y;
+    await page.waitForTimeout(120);
+  }
+
+  return last;
+}
+
+/** The href of the first movie card currently in the results grid, or ''. */
+function firstCardHref(page: Page): Promise<string> {
+  return page.evaluate(
+    () =>
+      document.querySelector('#content-container a[href^="/movie/"]')?.getAttribute('href') ?? '',
+  );
+}
+
+test('paginating lands at the top of the results, not the page top', async ({ page }) => {
+  // Delay the discover server action so the next page's results swap in while
+  // the scroll is still animating — the timing that dropped the scroll on
+  // Safari. The initial page load is a GET and is unaffected.
+  await page.route('**/discover**', async (route) => {
+    if (route.request().method() === 'POST') {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    await route.continue();
+  });
+
+  await page.goto('/discover');
+  const container = page.locator('#content-container');
+  const firstCard = container.locator('a[href^="/movie/"]').first();
+  await expect(firstCard).toBeVisible({ timeout: 20_000 });
+
+  // The results container's offset is stable across pages, so capture it while
+  // resting at the top: this is where "the top of the results" lives.
+  const containerTop = await page.evaluate(() => {
+    const el = document.querySelector('#content-container')!;
+    return Math.round(el.getBoundingClientRect().top + window.scrollY);
+  });
+
+  // Remember page 1's first result so we can tell when page 2 has swapped in.
+  const firstHrefBefore = await firstCardHref(page);
+  expect(firstHrefBefore).not.toBe('');
+
+  // Navigate away from a scrolled-down position, as a user at the bottom-of-page
+  // pagination controls would.
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(containerTop);
+
+  // Click Next, then wait past the loading skeletons until page 2's cards have
+  // actually replaced page 1's — the grid swap (and any scroll it disturbs)
+  // must have happened before we measure.
+  await page.getByRole('button', { name: /go to next page/i }).click();
+  await page.waitForURL(/page=2/);
+  await expect
+    .poll(
+      async () => {
+        const href = await firstCardHref(page);
+        return href !== '' && href !== firstHrefBefore;
+      },
+      { timeout: 20_000 },
+    )
+    .toBe(true);
+
+  const finalY = await settledScrollY(page);
+
+  // Lands on the results (top of the first item, minus the small scroll-margin
+  // gap) — not yanked to the page top (the bug) and not left far down the page.
+  expect(finalY).toBeGreaterThan(containerTop - SCROLL_MARGIN - 60);
+  expect(finalY).toBeLessThan(containerTop + 60);
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:install": "playwright install --with-deps chromium",
+    "e2e:install": "playwright install --with-deps chromium webkit",
     "fallow": "fallow audit",
     "fallow:dead-code": "fallow dead-code",
     "format": "oxfmt --write src",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,22 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      // The pagination-scroll regression only reproduces on mobile WebKit; it
+      // runs under the mobile-safari project below, not here.
+      testIgnore: /discover-pagination-scroll\.spec\.ts/,
+    },
+    {
+      // WebKit (the Safari engine) on an iPhone viewport, scoped to the mobile
+      // Safari scroll regression.
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 13'] },
+      testMatch: /discover-pagination-scroll\.spec\.ts/,
+    },
+  ],
   // Build + start the real app unless we were pointed at an external URL.
   webServer: useManagedServer
     ? {

--- a/src/lib/scroll-to-content.test.ts
+++ b/src/lib/scroll-to-content.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { scrollToContent } from './scroll-to-content';
+
+type ContainerStub = { scrollIntoView: ReturnType<typeof vi.fn>; top: number };
+
+/**
+ * Stubs the minimal `document`/`window` surface `scrollToContent` touches and
+ * returns helpers to fire the listeners it registers. Listeners are registered
+ * with an `AbortSignal`, so removal happens via the signal. `container.top` is
+ * the results container's viewport-relative top; set it to the scroll-margin
+ * (20) to represent "on target".
+ */
+function stubEnv(container: ContainerStub | null) {
+  const listeners: Record<string, Set<() => void>> = {};
+  const scrollTo = vi.fn();
+
+  vi.stubGlobal('document', {
+    querySelector: vi.fn().mockReturnValue(
+      container
+        ? {
+            scrollIntoView: container.scrollIntoView,
+            getBoundingClientRect: () => ({ top: container.top }),
+          }
+        : null,
+    ),
+  });
+  vi.stubGlobal('window', {
+    scrollY: 0,
+    scrollTo,
+    addEventListener: (type: string, fn: () => void, options?: { signal?: AbortSignal }) => {
+      (listeners[type] ??= new Set()).add(fn);
+      options?.signal?.addEventListener('abort', () => listeners[type]?.delete(fn), {
+        once: true,
+      });
+    },
+  });
+
+  return {
+    scrollTo,
+    fire: (type: string) => listeners[type]?.forEach((fn) => fn()),
+    listenerCount: () => Object.values(listeners).reduce((n, set) => n + set.size, 0),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('scrollToContent', () => {
+  it('smooth-scrolls the results container to the top', () => {
+    const scrollIntoView = vi.fn();
+    stubEnv({ scrollIntoView, top: 20 });
+
+    scrollToContent();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('falls back to the top of the page when no container is present', () => {
+    const { scrollTo } = stubEnv(null);
+
+    scrollToContent();
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('re-asserts the target when a later scroll drifts off it', () => {
+    const scrollIntoView = vi.fn();
+    // Container sits 300px down: a soft-navigation scroll has drifted off target.
+    const { fire } = stubEnv({ scrollIntoView, top: 300 });
+
+    scrollToContent();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    fire('scroll');
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves an on-target scroll alone', () => {
+    const scrollIntoView = vi.fn();
+    // Container top === scroll-margin: already on target.
+    const { fire } = stubEnv({ scrollIntoView, top: 20 });
+
+    scrollToContent();
+    fire('scroll');
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('yields to the user and tears down its listeners on touchmove', () => {
+    const scrollIntoView = vi.fn();
+    const { fire, listenerCount } = stubEnv({ scrollIntoView, top: 300 });
+
+    scrollToContent();
+    fire('touchmove');
+    expect(listenerCount()).toBe(0);
+
+    // A drift after the user took over must not be corrected.
+    fire('scroll');
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops guarding after the guard window elapses', () => {
+    vi.useFakeTimers();
+    const scrollIntoView = vi.fn();
+    const { fire, listenerCount } = stubEnv({ scrollIntoView, top: 300 });
+
+    scrollToContent();
+    expect(listenerCount()).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(1200);
+    expect(listenerCount()).toBe(0);
+
+    fire('scroll');
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('supersedes the previous guard when called again', () => {
+    const scrollIntoView = vi.fn();
+    const first = stubEnv({ scrollIntoView, top: 300 });
+
+    scrollToContent();
+    expect(first.listenerCount()).toBeGreaterThan(0);
+
+    // A second click (fresh stubs, as after a re-render) replaces the guard:
+    // the first guard's listeners are aborted, only the new ones remain.
+    const second = stubEnv({ scrollIntoView, top: 300 });
+    scrollToContent();
+
+    expect(first.listenerCount()).toBe(0);
+    expect(second.listenerCount()).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/scroll-to-content.ts
+++ b/src/lib/scroll-to-content.ts
@@ -1,17 +1,76 @@
-/**
- * Scrolls the results container (`#content-container`) to the top of the
- * viewport, falling back to the top of the page when no container is present.
- *
- * Call this from a user gesture (e.g. a pagination link's `onClick`) rather than
- * an effect: the container's position is stable across page changes, so scrolling
- * on click is reliable on mobile and never fires on unrelated navigation (back /
- * forward, deep links) the way a `page`-watching effect does.
- */
-export function scrollToContent() {
-  const container = document.querySelector('#content-container');
+// Matches the `scroll-m-5` (1.25rem) scroll-margin on `#content-container`:
+// resting with the container this far below the viewport top is on-target.
+const SCROLL_MARGIN = 20;
+
+// Sub-pixel layout and smooth-scroll rounding keep the settled position within
+// a few px of the target; anything past this is a scroll we didn't ask for.
+const ON_TARGET_TOLERANCE = 4;
+
+// How long to defend the target after the click. WebKit fires its own scroll
+// a few hundred ms after a soft navigation's `pushState`; the window must
+// outlast that, with margin for slow devices.
+const GUARD_MS = 1200;
+
+// The one guard allowed at a time; a new click supersedes the previous guard.
+let activeGuard: AbortController | null = null;
+
+function getContainer() {
+  return document.querySelector('#content-container');
+}
+
+function scrollToTarget() {
+  const container = getContainer();
   if (container) {
     container.scrollIntoView({ behavior: 'smooth', block: 'start' });
   } else {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
+}
+
+/** Signed distance from the target position, in px (0 = on target). */
+function offsetFromTarget() {
+  const container = getContainer();
+  return container ? container.getBoundingClientRect().top - SCROLL_MARGIN : window.scrollY;
+}
+
+/**
+ * Scrolls the results container (`#content-container`) to the top of the
+ * viewport, falling back to the top of the page when no container is present.
+ * The container's `scroll-margin` leaves a small gap above the first item.
+ *
+ * Call this from a user gesture (e.g. a pagination link's `onClick`) rather than
+ * an effect: the container's position is stable across page changes, so scrolling
+ * on click is reliable and never fires on unrelated navigation (back / forward,
+ * deep links) the way a `page`-watching effect does.
+ *
+ * A single `scrollIntoView` isn't enough on WebKit/iOS Safari: paginating is a
+ * soft navigation, and Safari runs its own scroll ~300ms after the `pushState`,
+ * landing partway up the page and clobbering ours. So for a short window after
+ * scrolling, any scroll that drifts off the target is steered back — unless it
+ * came from the user (wheel / touchmove / keydown), which ends the guard.
+ */
+export function scrollToContent() {
+  scrollToTarget();
+
+  activeGuard?.abort();
+  const guard = new AbortController();
+  activeGuard = guard;
+
+  function endGuard() {
+    guard.abort();
+  }
+
+  function steerBackIfOffTarget() {
+    if (Math.abs(offsetFromTarget()) > ON_TARGET_TOLERANCE) {
+      scrollToTarget();
+    }
+  }
+
+  const { signal } = guard;
+  window.addEventListener('scroll', steerBackIfOffTarget, { passive: true, signal });
+  // `touchmove` rather than `touchstart`, so a stray tap doesn't end the guard.
+  window.addEventListener('wheel', endGuard, { passive: true, signal });
+  window.addEventListener('touchmove', endGuard, { passive: true, signal });
+  window.addEventListener('keydown', endGuard, { signal });
+  setTimeout(endGuard, GUARD_MS);
 }


### PR DESCRIPTION
## What

On mobile (iOS Safari), tapping a discover pagination link left the viewport partway up the page (Discover header / toolbar) instead of at the top of the first result.

## Root cause (found with a real WebKit repro)

Paginating is a **soft navigation** (client-side `pushState` via nuqs). On WebKit/iOS Safari, the browser runs **its own scroll ~300ms after the pushState**, clobbering the scroll fired on click. Chromium never does this, which is why it only showed up on mobile Safari.

A single `scrollIntoView` can't win the race: Safari's jump happens *after* ours has settled (confirmed by sampling `window.scrollY` over time in a WebKit container). `behavior: 'instant'` and `history.scrollRestoration = 'manual'` were tried and ruled out against the repro.

## Fix

`scrollToContent` scrolls as before, then defends the target for a short window (1.2s): a `scroll` listener steers back if anything drifts the viewport off-target, and any real user input (`wheel` / `touchmove` / `keydown`) ends the guard immediately so it never fights a gesture. All guard teardown goes through one `AbortController` (listeners registered with its `signal`), and a new pagination click supersedes the previous guard.

Loading behavior is untouched: pagination still shows the skeletons while the next page loads (no `keepPreviousData`). `#content-container` itself stays mounted through the skeleton swap, so the guard always has a stable target.

## Tests

- **New `mobile-safari` Playwright project** (WebKit + iPhone viewport) running `e2e/discover-pagination-scroll.spec.ts`, which reproduces the jump (throttled data so the skeleton → results swap lands mid-scroll) and asserts the landing position. Confirmed **red without the fix / green with it** on real WebKit via the official Playwright container.
- Unit coverage for the guard: initial scroll, fallback, re-assert-on-drift, leave-on-target, yield-to-user, teardown-after-window, and supersede-on-reclick.
- `e2e:install` now installs `webkit` alongside `chromium`.
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (307 passed), `pnpm fallow` all green.

> Note: WebKit can't launch directly on my Arch dev box, so e2e verification ran inside the official `mcr.microsoft.com/playwright` container against a dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
