### PR TITLE
🧱 fix failing imdb-ingest PR check (pin to PR branch in previews)

### DIFF
--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -110,7 +110,12 @@ export default defineRailway((ctx) => {
   // Previews ingest into their own postgres instead (and get real IMDb data);
   // IMDb refreshes the datasets early UTC, so run shortly after.
   const imdbIngest = service("imdb-ingest", {
-    source: github("emmut/movies"),
+    // Track the PR branch in previews, same as the movies service. Left on the
+    // default branch, a PR environment first deploys imdb-ingest at the PR
+    // commit and then the infra apply redeploys it at main, cancelling the
+    // first — and Railway reports that cancelled deployment as a failed PR
+    // check. Pinning the branch keeps the single deployment green.
+    source: github("emmut/movies", prod ? {} : { branch: currentGitBranch() }),
     // The cron only needs dependencies + tsx; Railpack's default
     // `pnpm run build` would run `next build`, which fails env validation
     // since this service only has DATABASE_URL.


### PR DESCRIPTION
## Problem

The `movies - imdb-ingest` check fails on PRs with **"Deployment cancelled"** (e.g. #267), even though the service runs fine.

## Cause

Deployments for imdb-ingest in a PR environment:

| Deployment | Commit | Status |
|---|---|---|
| `92348d45` | PR commit | **REMOVED** ← the check is bound to this one |
| `f1e1bd29` | `main` | SUCCESS (23s later) |

The imdb-ingest service source was **not branch-pinned** (`github("emmut/movies")`), unlike the movies service (`github("emmut/movies", prod ? {} : { branch: currentGitBranch() })`). So a PR env first deploys imdb-ingest at the PR commit, then the infra apply resolves its source to `main` and redeploys — cancelling the first deployment. Railway reports that cancelled deployment as a failed PR check. The movies service, being branch-pinned, only deploys once and stays green.

## Fix

Pin imdb-ingest's source to the PR branch in previews, identical to the movies service. Single deployment, no cancellation, green check. Production still tracks the default branch (`prod ? {}`).

Note: this is unrelated to the E2E failures on the other PRs (that's the `detail-scroll` tv test — separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)