### PR TITLE
✅ fix flaky detail-scroll e2e (navigate to stable destinations)

### DIFF
--- a/e2e/detail-scroll.spec.ts
+++ b/e2e/detail-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 
 import { MOVIE_PATH } from './helpers';
 
@@ -12,32 +12,30 @@ import { MOVIE_PATH } from './helpers';
 // person skeleton with the (already-short) movie/tv ones. These tests pin the
 // invariant for all three: navigating in from a scrolled position lands at the
 // top once the real content has replaced the skeleton.
+//
+// Destinations are reached from a stable person / movie whose top-billed links
+// resolve to well-known titles. Navigating into whatever happened to be last on
+// discover was flaky: that item changes daily, and an obscure title's detail
+// page can be slow to stream (or 404), so the heading never appeared in time.
 
 /**
- * From a source page listing links of a given kind, navigates into one from a
- * scrolled-down position and asserts the destination lands at the top.
- *
- * Clicking an in-app link is a client-side navigation, so the destination's
- * `loading.tsx` boundary renders before the real content arrives — exactly the
- * path the scroll bug lived on.
+ * From a scrolled-down position, clicks `link` (a client-side navigation into a
+ * detail route) and asserts the destination lands at the top once its real
+ * content has replaced the loading skeleton.
  *
  * @param page - The Playwright page.
- * @param linkSelector - CSS selector matching links to the target detail route.
+ * @param link - A locator for the in-app link to click.
  * @param urlPattern - Expected destination URL.
  */
-async function expectNavigationLandsAtTop(page: Page, linkSelector: string, urlPattern: RegExp) {
-  // The source page's own level-1 heading, if it has one (the discover page's
-  // title is an <h2>, the movie page's is an <h1>). Used below to tell the
-  // destination content apart from the still-visible source route mid-transition.
+async function expectNavigationLandsAtTop(page: Page, link: Locator, urlPattern: RegExp) {
+  // The source page's own level-1 heading, if any, so we can tell the
+  // destination's <h1> apart from a source heading left visible mid-transition.
   const h1 = page.getByRole('heading', { level: 1 });
   const sourceHeading = (await h1.count()) > 0 ? (await h1.first().textContent())?.trim() : undefined;
 
-  // Drop to the bottom so we navigate away from a scrolled-down position.
+  // Drop to the bottom, then bring the link into view, so we navigate away from
+  // a scrolled-down position rather than the top.
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-
-  // The last matching link sits near the bottom, so clicking it keeps us
-  // scrolled down rather than yanking back to the top before navigating.
-  const link = page.locator(linkSelector).last();
   await link.scrollIntoViewIfNeeded();
   expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(200);
   await link.click();
@@ -51,9 +49,6 @@ async function expectNavigationLandsAtTop(page: Page, linkSelector: string, urlP
   // destination's <h1> carries the title; when the source has its own <h1> we
   // exclude its text so we don't match the still-visible source heading.
   const destinationHeading = sourceHeading ? h1.filter({ hasNotText: sourceHeading }) : h1;
-  // Detail pages stream in behind a loading.tsx skeleton once their server
-  // component resolves; on a cold server that can take longer than the default
-  // 5s assertion timeout, so give the heading the same headroom as the link.
   await expect(destinationHeading.first()).toBeVisible({ timeout: 15_000 });
 
   // Once the real content is in, the viewport should be at the top.
@@ -62,22 +57,25 @@ async function expectNavigationLandsAtTop(page: Page, linkSelector: string, urlP
     .toBeLessThan(50);
 }
 
-test('navigating into a movie page from a scrolled position lands at the top', async ({ page }) => {
-  await page.goto('/discover');
-  await expect(page.locator('#content-container a[href^="/movie/"]').first()).toBeVisible({
-    timeout: 15_000,
-  });
+// Stable people with deep filmographies; their top-billed (most popular) credit
+// is a well-known title whose detail page streams in quickly.
+const MOVIE_STAR_PATH = '/person/6193'; // Leonardo DiCaprio — top movie credits
+const TV_STAR_PATH = '/person/17419'; // Bryan Cranston — top tv credits
 
-  await expectNavigationLandsAtTop(page, '#content-container a[href^="/movie/"]', /\/movie\/\d+/);
+test('navigating into a movie page from a scrolled position lands at the top', async ({ page }) => {
+  await page.goto(MOVIE_STAR_PATH);
+  const topMovie = page.locator('a[href^="/movie/"]').first();
+  await expect(topMovie).toBeVisible({ timeout: 15_000 });
+
+  await expectNavigationLandsAtTop(page, topMovie, /\/movie\/\d+/);
 });
 
 test('navigating into a tv page from a scrolled position lands at the top', async ({ page }) => {
-  await page.goto('/discover?mediaType=tv');
-  await expect(page.locator('#content-container a[href^="/tv/"]').first()).toBeVisible({
-    timeout: 15_000,
-  });
+  await page.goto(TV_STAR_PATH);
+  const topTv = page.locator('a[href^="/tv/"]').first();
+  await expect(topTv).toBeVisible({ timeout: 15_000 });
 
-  await expectNavigationLandsAtTop(page, '#content-container a[href^="/tv/"]', /\/tv\/\d+/);
+  await expectNavigationLandsAtTop(page, topTv, /\/tv\/\d+/);
 });
 
 test('navigating into a person page from a scrolled position lands at the top', async ({
@@ -87,5 +85,5 @@ test('navigating into a person page from a scrolled position lands at the top', 
   await page.goto(MOVIE_PATH);
   await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-  await expectNavigationLandsAtTop(page, 'a[href^="/person/"]', /\/person\/\d+/);
+  await expectNavigationLandsAtTop(page, page.locator('a[href^="/person/"]').last(), /\/person\/\d+/);
 });


### PR DESCRIPTION
## Why

The `detail-scroll` movie/tv tests navigated into **whatever was last on discover**, which changes daily. When that item is obscure, its detail page streams in slowly (or 404s), so the destination `<h1>` doesn't appear in time and the test flakes. This is what turned main red after #269 merged (today's last tv item, `296206`, is a slow/not-found page) — it's a pre-existing test-design issue, not a regression from #269's DB work.

Evidence: on the failing runs the destination `main` was just header + footer (the ARIA snapshot omits skeleton `<div>`s), i.e. the page was still on its loading skeleton after 15s.

## Fix

Navigate from **stable people** into their **top-billed (most popular) credit**, which is a well-known title whose detail page renders fast and deterministically:
- movie → `/person/6193` (Leonardo DiCaprio) → first `/movie/` credit
- tv → `/person/17419` (Bryan Cranston) → first `/tv/` credit
- person → unchanged (Inception → cast)

The helper now takes the resolved `Locator` so each test picks its own link.

## Verification note

I couldn't get a trustworthy local run: my own testing this session rate-limited TMDb on the local prod build, so detail pages there kept stalling on their skeletons regardless of the change (the person test, which makes fewer TMDb calls, passed). CI has a clean TMDb quota — this PR's CI run is the real check. Lint + typecheck pass locally.