### PR TITLE
🐛 wait out short TMDb Retry-After windows instead of failing the page

### DIFF
--- a/src/lib/tmdb.test.ts
+++ b/src/lib/tmdb.test.ts
@@ -141,6 +141,38 @@ describe('tmdbFetch', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('stops retrying once slow attempts plus Retry-After waits exhaust the time budget', async () => {
+    // Each attempt takes ~6s to come back 429 with a 6s window. Unbounded, the
+    // loop would spend ~30s (3 slow attempts + two 6s waits); the budget must
+    // surface the failure after the second attempt instead.
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(jsonResponse(null, 429, { 'retry-after': '6' })), 5900);
+        }),
+    );
+
+    const start = Date.now();
+    await expect(
+      withTimersFlushed(tmdbFetch('/movie/1', { errorMessage: 'Rate limited' })),
+    ).rejects.toThrow('Rate limited');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Fake timers drive Date.now, so this measures the simulated wall clock.
+    expect(Date.now() - start).toBeLessThan(20_000);
+  });
+
+  it('stops retrying a slow network error once the time budget is spent', async () => {
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('ECONNRESET')), 6000);
+        }),
+    );
+
+    await expect(withTimersFlushed(tmdbFetch('/movie/1'))).rejects.toThrow('ECONNRESET');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('fails fast on a timeout without retrying (a hung upstream should degrade)', async () => {
     fetchMock.mockRejectedValue(
       new DOMException('The operation timed out.', 'TimeoutError'),

--- a/src/lib/tmdb.test.ts
+++ b/src/lib/tmdb.test.ts
@@ -119,8 +119,9 @@ describe('tmdbFetch', () => {
   });
 
   it('honors a Retry-After within the cap and retries once the window closes', async () => {
+    // 3s is TMDb's common short window; it must be waited out, not failed.
     fetchMock
-      .mockResolvedValueOnce(jsonResponse(null, 429, { 'retry-after': '1' }))
+      .mockResolvedValueOnce(jsonResponse(null, 429, { 'retry-after': '3' }))
       .mockResolvedValueOnce(jsonResponse({ id: 8 }));
 
     const result = await withTimersFlushed(tmdbFetch<{ id: number }>('/movie/8'));

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -21,11 +21,14 @@ const RETRY_BASE_MS = 250;
 // request for ~30s before returning a 504) aborts quickly and either retries or
 // falls back, instead of stalling the page render on a single slow endpoint.
 const REQUEST_TIMEOUT_MS = 6000;
-// Longest upstream-specified rate-limit window (Retry-After) we'll wait out. A
-// window longer than this can't be ridden out within our attempt budget, so we
-// surface the 429 immediately and let the caller degrade rather than fire more
-// requests inside the still-open window (which only adds load and still fails).
-const MAX_RETRY_AFTER_MS = 2000;
+// Longest upstream-specified rate-limit window (Retry-After) we'll wait out,
+// aligned with REQUEST_TIMEOUT_MS: a render already tolerates that long on a
+// single attempt, so common short windows (Retry-After: 3–5) are worth riding
+// out instead of failing the page. Anything longer can't be ridden out within
+// a render, so we surface the 429 immediately and let the caller degrade
+// rather than fire more requests inside the still-open window (which only
+// adds load and still fails).
+const MAX_RETRY_AFTER_MS = REQUEST_TIMEOUT_MS;
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -29,6 +29,11 @@ const REQUEST_TIMEOUT_MS = 6000;
 // rather than fire more requests inside the still-open window (which only
 // adds load and still fails).
 const MAX_RETRY_AFTER_MS = REQUEST_TIMEOUT_MS;
+// Total budget for one fetch including retry waits. Per-attempt caps alone
+// still stack: three 6s attempts plus two 6s Retry-After waits is ~30s, enough
+// to hit the deployment's request deadline instead of rendering a degraded
+// page. Once a retry wait would cross this deadline we surface what we have.
+const RETRY_BUDGET_MS = 2 * REQUEST_TIMEOUT_MS;
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -68,7 +73,12 @@ function isTimeout(error: unknown) {
   return error instanceof DOMException && error.name === 'TimeoutError';
 }
 
-async function fetchWithRetry(url: URL, init: RequestInit, attempt = 1): Promise<Response> {
+async function fetchWithRetry(
+  url: URL,
+  init: RequestInit,
+  attempt = 1,
+  deadline = Date.now() + RETRY_BUDGET_MS,
+): Promise<Response> {
   let backoffMs = RETRY_BASE_MS * attempt;
 
   try {
@@ -88,17 +98,20 @@ async function fetchWithRetry(url: URL, init: RequestInit, attempt = 1): Promise
       }
       backoffMs = retryAfter;
     }
+    if (Date.now() + backoffMs > deadline) {
+      return res;
+    }
   } catch (error) {
     // A timeout means the upstream is hanging (TMDb's CloudFront can sit on a
     // request for ~30s). Retrying just stacks more waiting, so fail fast and let
     // the caller degrade; only fast transient errors are worth another attempt.
-    if (isTimeout(error) || attempt >= MAX_ATTEMPTS) {
+    if (isTimeout(error) || attempt >= MAX_ATTEMPTS || Date.now() + backoffMs > deadline) {
       throw error;
     }
   }
 
   await sleep(backoffMs);
-  return fetchWithRetry(url, init, attempt + 1);
+  return fetchWithRetry(url, init, attempt + 1, deadline);
 }
 
 /**


### PR DESCRIPTION
## What

A 429 with a valid `Retry-After` longer than 2s was surfaced on the **first attempt**, without using the remaining retry budget. Essential fetchers (`getMovieDetails`, `getTvShowDetails`, `getPersonDetails`) propagate that error, so a common `Retry-After: 3` failed the whole detail page.

## Fix

Raise `MAX_RETRY_AFTER_MS` from 2s to `REQUEST_TIMEOUT_MS` (6s): a render already tolerates 6s on a single hung attempt, so refusing to wait 3s for a *guaranteed-open* window was inconsistent. Short windows (3–5s) are now waited out and retried.

Genuinely long windows (e.g. `Retry-After: 30`) still fail fast by design — no attempt budget can ride out 30s inside a server render, and retrying inside the window only adds load and still returns 429. `optional()` degradation at call sites remains the right handling there.

## Tests

- Updated the within-cap test to `Retry-After: 3` — the reported failing value — asserting it's waited out and succeeds on the next attempt.
- The fail-fast-at-30s test is unchanged and still passes.
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (307 passed), `pnpm fallow` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
