### PR TITLE
💄 render detail loading skeletons full-height, opaque footer

### DIFF
--- a/e2e/detail-scroll.spec.ts
+++ b/e2e/detail-scroll.spec.ts
@@ -87,3 +87,19 @@ test('navigating into a person page from a scrolled position lands at the top', 
 
   await expectNavigationLandsAtTop(page, page.locator('a[href^="/person/"]').last(), /\/person\/\d+/);
 });
+
+test.describe('narrow viewport', () => {
+  // At desktop size the person skeleton happens to fit in one viewport, so the
+  // browser clamps scroll to the top even without the skeleton's height cap and
+  // the test above can't regress. In the single-column mobile layout the
+  // uncapped skeleton is taller than the viewport, which is where an incoming
+  // navigation actually retained its scroll offset.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('navigating into a person page lands at the top on a small screen', async ({ page }) => {
+    await page.goto(MOVIE_PATH);
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    await expectNavigationLandsAtTop(page, page.locator('a[href^="/person/"]').last(), /\/person\/\d+/);
+  });
+});

--- a/src/app/movie/[movieId]/loading.tsx
+++ b/src/app/movie/[movieId]/loading.tsx
@@ -3,11 +3,10 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function LoadingMovies() {
   return (
-    // Clip to under one viewport so a client-side navigation from a scrolled
-    // position can't retain its offset: a short skeleton document lets the
-    // browser clamp scroll back to the top before the real content streams in.
-    // Guarded by e2e/detail-scroll.spec.ts.
-    <div className="max-h-[80dvh] overflow-hidden">
+    // Rendered full-height, no clipping: landing at the top after a scrolled
+    // client-side navigation is the scroll handler's job (see next.config.ts),
+    // guarded by e2e/detail-scroll.spec.ts.
+    <div>
       <div className="mb-6">
         <Skeleton className="h-10 w-24" />
       </div>

--- a/src/app/person/[id]/loading.tsx
+++ b/src/app/person/[id]/loading.tsx
@@ -4,11 +4,13 @@ import { Skeleton } from '@/components/ui/skeleton';
  * Displays a compact loading skeleton for the person detail page.
  *
  * Mirrors the above-the-fold layout of the person page (go-back control, profile
- * image, name, stats, and biography intro) while staying short enough to avoid
- * shifting the scroll position when the real content replaces it.
+ * image, name, stats, and biography intro).
  */
 export default function LoadingPerson() {
   return (
+    // Rendered full-height, no clipping: landing at the top after a scrolled
+    // client-side navigation is the scroll handler's job (see next.config.ts),
+    // guarded by e2e/detail-scroll.spec.ts.
     <div>
       <div className="mb-6">
         <Skeleton className="h-10 w-24" />

--- a/src/app/tv/[tvId]/loading.tsx
+++ b/src/app/tv/[tvId]/loading.tsx
@@ -3,11 +3,10 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function LoadingTvShows() {
   return (
-    // Clip to under one viewport so a client-side navigation from a scrolled
-    // position can't retain its offset: a short skeleton document lets the
-    // browser clamp scroll back to the top before the real content streams in.
-    // Guarded by e2e/detail-scroll.spec.ts.
-    <div className="max-h-[80dvh] overflow-hidden">
+    // Rendered full-height, no clipping: landing at the top after a scrolled
+    // client-side navigation is the scroll handler's job (see next.config.ts),
+    // guarded by e2e/detail-scroll.spec.ts.
+    <div>
       <div className="mb-6">
         <Skeleton className="h-10 w-24" />
       </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,7 +2,9 @@ import Image from 'next/image';
 
 function Footer() {
   return (
-    <footer className="mt-auto pt-16">
+    // Solid background (plus `relative` to lift it in paint order) so page
+    // content streaming in mid-transition never shows through the footer.
+    <footer className="relative mt-auto bg-background pt-16">
       <div className="mx-auto flex max-w-2xl flex-col items-center gap-4 border-t border-zinc-800/60 px-4 pt-10 pb-10 text-center">
         <a href="https://www.themoviedb.org/" target="_blank" rel="noopener noreferrer">
           <Image


### PR DESCRIPTION
The max-h-[80dvh] clip chopped the loading ghost mid-element; the scroll reset on client-side navigation is handled by appNewScrollHandler, so the cap wasn't load-bearing (verified in chromium + webkit against a prod build). Footer gets a solid background so streaming content can't show through it. Adds a narrow-viewport person e2e where a too-tall skeleton would actually retain scroll.