### PR TITLE
🔧 remove experimental appNewScrollHandler

### DIFF
--- a/e2e/detail-scroll.spec.ts
+++ b/e2e/detail-scroll.spec.ts
@@ -88,6 +88,39 @@ test('navigating into a person page from a scrolled position lands at the top', 
   await expectNavigationLandsAtTop(page, page.locator('a[href^="/person/"]').last(), /\/person\/\d+/);
 });
 
+test.describe('clamp-window viewport', () => {
+  // Regression for the screen-size-dependent variant: when the destination's
+  // loading skeleton is only a few dozen px taller than the viewport, the
+  // browser clamps the retained scroll offset to less than the segment's
+  // document offset (~80px of header + padding), the segment's top edge stays
+  // visible, and Next's stock scroll handler early-exited without scrolling —
+  // fossilizing the offset once the real content streamed in (fixed in
+  // patches/next.patch). At 1480x864 the person skeleton (926px) leaves
+  // exactly 62px of clamped scroll. Needs streaming latency to reproduce, so
+  // the connection is throttled; an instant response commits URL, skeleton,
+  // and content together and the bug window never opens.
+  test.use({ viewport: { width: 1480, height: 864 } });
+
+  test('navigating into a person page lands at the top when the skeleton barely exceeds the viewport', async ({
+    page,
+  }) => {
+    // Stable long-lived show whose cast links to person pages.
+    await page.goto('/tv/555');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    const client = await page.context().newCDPSession(page);
+    await client.send('Network.enable');
+    await client.send('Network.emulateNetworkConditions', {
+      offline: false,
+      latency: 150,
+      downloadThroughput: (2000 * 1024) / 8,
+      uploadThroughput: 1024 * 1024,
+    });
+
+    await expectNavigationLandsAtTop(page, page.locator('a[href^="/person/"]').last(), /\/person\/\d+/);
+  });
+});
+
 test.describe('narrow viewport', () => {
   // At desktop size the person skeleton happens to fit in one viewport, so the
   // browser clamps scroll to the top even without the skeleton's height cap and

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,12 +7,6 @@ env;
 const nextConfig: NextConfig = {
   reactCompiler: true,
   cacheComponents: true,
-  experimental: {
-    // The legacy scroll handler chokes on head-hoisted preload links and can
-    // leave client-side navigations into detail routes scrolled partway down
-    // (guarded by e2e/detail-scroll.spec.ts; reproduces only in prod builds).
-    appNewScrollHandler: true,
-  },
   async headers() {
     return [
       {

--- a/patches/next.patch
+++ b/patches/next.patch
@@ -1,0 +1,48 @@
+diff --git a/dist/client/components/layout-router.js b/dist/client/components/layout-router.js
+index 06b68cc92862992b485d8f3edf0a937e0af2847a..472e9060b10c681b4e4842200a5825bd5ba39de9 100644
+--- a/dist/client/components/layout-router.js
++++ b/dist/client/components/layout-router.js
+@@ -145,12 +145,13 @@ class InnerScrollAndFocusHandlerOld extends _react.default.Component {
+             // Verify if the element is a HTMLElement and if we want to consider it for scroll behavior.
+             // If the element is skipped, try to select the next sibling and try again.
+             while(!(domNode instanceof HTMLElement) || shouldSkipElement(domNode)){
+-                if (process.env.NODE_ENV !== 'production') {
+-                    if (domNode.parentElement?.localName === 'head') {
+-                    // We enter this state when metadata was rendered as part of the page or via Next.js.
+-                    // This is always a bug in Next.js and caused by React hoisting metadata.
+-                    // Fixed with `experimental.appNewScrollHandler`
+-                    }
++                // PATCHED(movies): React hoisted the segment's first node (e.g. a
++                // stylesheet <link>) into <head>; the sibling walk would die there
++                // and the navigation would silently keep its scroll offset.
++                // Restart the walk from <body> so route changes still scroll.
++                if (domNode.parentElement?.localName === 'head') {
++                    domNode = document.body;
++                    continue;
+                 }
+                 // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
+                 if (domNode.nextElementSibling === null) {
+diff --git a/dist/esm/client/components/layout-router.js b/dist/esm/client/components/layout-router.js
+index 25e44ba48e03b6ae3eb6de3ddacfdcc8f43f185d..4e47eb1cad22667039b0f5d11b0634079d9a0423 100644
+--- a/dist/esm/client/components/layout-router.js
++++ b/dist/esm/client/components/layout-router.js
+@@ -118,12 +118,13 @@ class InnerScrollAndFocusHandlerOld extends React.Component {
+             // Verify if the element is a HTMLElement and if we want to consider it for scroll behavior.
+             // If the element is skipped, try to select the next sibling and try again.
+             while(!(domNode instanceof HTMLElement) || shouldSkipElement(domNode)){
+-                if (process.env.NODE_ENV !== 'production') {
+-                    if (domNode.parentElement?.localName === 'head') {
+-                    // We enter this state when metadata was rendered as part of the page or via Next.js.
+-                    // This is always a bug in Next.js and caused by React hoisting metadata.
+-                    // Fixed with `experimental.appNewScrollHandler`
+-                    }
++                // PATCHED(movies): React hoisted the segment's first node (e.g. a
++                // stylesheet <link>) into <head>; the sibling walk would die there
++                // and the navigation would silently keep its scroll offset.
++                // Restart the walk from <body> so route changes still scroll.
++                if (domNode.parentElement?.localName === 'head') {
++                    domNode = document.body;
++                    continue;
+                 }
+                 // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
+                 if (domNode.nextElementSibling === null) {

--- a/patches/next.patch
+++ b/patches/next.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/client/components/layout-router.js b/dist/client/components/layout-router.js
-index 06b68cc92862992b485d8f3edf0a937e0af2847a..472e9060b10c681b4e4842200a5825bd5ba39de9 100644
+index 06b68cc92862992b485d8f3edf0a937e0af2847a..0f13c2f8dec60ce74434e6c75da6490d7e3222c2 100644
 --- a/dist/client/components/layout-router.js
 +++ b/dist/client/components/layout-router.js
 @@ -145,12 +145,13 @@ class InnerScrollAndFocusHandlerOld extends _react.default.Component {
@@ -22,8 +22,24 @@ index 06b68cc92862992b485d8f3edf0a937e0af2847a..472e9060b10c681b4e4842200a5825bd
                  }
                  // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
                  if (domNode.nextElementSibling === null) {
+@@ -170,8 +171,13 @@ class InnerScrollAndFocusHandlerOld extends _react.default.Component {
+                 // and it won't change during this function.
+                 const htmlElement = document.documentElement;
+                 const viewportHeight = htmlElement.clientHeight;
+-                // If the element's top edge is already in the viewport, exit early.
+-                if (topOfElementInViewport(domNode, viewportHeight)) {
++                // PATCHED(movies): only skip scrolling when the page is already at
++                // the top. When a short loading skeleton is barely taller than the
++                // viewport, the browser clamps the retained scroll offset to a few
++                // dozen pixels, which leaves the segment's top edge visible; the
++                // stock early-exit then treated that as "no scroll needed" and the
++                // navigation stayed scrolled down forever (screen-size dependent).
++                if (window.scrollY === 0 && topOfElementInViewport(domNode, viewportHeight)) {
+                     return;
+                 }
+                 // Otherwise, try scrolling go the top of the document to be backward compatible with pages
 diff --git a/dist/esm/client/components/layout-router.js b/dist/esm/client/components/layout-router.js
-index 25e44ba48e03b6ae3eb6de3ddacfdcc8f43f185d..4e47eb1cad22667039b0f5d11b0634079d9a0423 100644
+index 25e44ba48e03b6ae3eb6de3ddacfdcc8f43f185d..a86edc932d359615b462e4c38e401a3cf023cbf2 100644
 --- a/dist/esm/client/components/layout-router.js
 +++ b/dist/esm/client/components/layout-router.js
 @@ -118,12 +118,13 @@ class InnerScrollAndFocusHandlerOld extends React.Component {
@@ -46,3 +62,19 @@ index 25e44ba48e03b6ae3eb6de3ddacfdcc8f43f185d..4e47eb1cad22667039b0f5d11b063407
                  }
                  // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
                  if (domNode.nextElementSibling === null) {
+@@ -143,8 +144,13 @@ class InnerScrollAndFocusHandlerOld extends React.Component {
+                 // and it won't change during this function.
+                 const htmlElement = document.documentElement;
+                 const viewportHeight = htmlElement.clientHeight;
+-                // If the element's top edge is already in the viewport, exit early.
+-                if (topOfElementInViewport(domNode, viewportHeight)) {
++                // PATCHED(movies): only skip scrolling when the page is already at
++                // the top. When a short loading skeleton is barely taller than the
++                // viewport, the browser clamps the retained scroll offset to a few
++                // dozen pixels, which leaves the segment's top edge visible; the
++                // stock early-exit then treated that as "no scroll needed" and the
++                // navigation stayed scrolled down forever (screen-size dependent).
++                if (window.scrollY === 0 && topOfElementInViewport(domNode, viewportHeight)) {
+                     return;
+                 }
+                 // Otherwise, try scrolling go the top of the document to be backward compatible with pages

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   postcss@<8.5.10: ^8.5.19
 
 patchedDependencies:
-  next: c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b
+  next: 5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578
   railway: ae82e735058108483939c04fb4af5e1f5feb6180ff6d056d5a6dd6db99a63f98
 
 importers:
@@ -21,7 +21,7 @@ importers:
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/passkey':
         specifier: ^1.6.23
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -54,7 +54,7 @@ importers:
         version: 19.1.0-rc.3
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
+        version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -72,10 +72,10 @@ importers:
         version: 1.24.0(react@19.2.7)
       next:
         specifier: 16.2.10
-        version: 16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: ^2.9.0
-        version: 2.9.0(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.9.0(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -3842,14 +3842,14 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)':
+  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.2
-      better-auth: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
+      better-auth: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
       better-call: 1.3.7(zod@4.4.3)
       nanostores: 1.4.0
       zod: 4.4.3
@@ -4871,7 +4871,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.41: {}
 
-  better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
+  better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))
@@ -4893,7 +4893,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)
-      next: 16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       pg: 8.22.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -5675,7 +5675,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -5712,12 +5712,12 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nuqs@2.9.0(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  nuqs@2.9.0(next@16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.7
     optionalDependencies:
-      next: 16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(patch_hash=5985d1e0c1dfbdc7145c822151bfd04dbb6aca68acb080e1730d61f112dd1578)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   object-assign@4.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   postcss@<8.5.10: ^8.5.19
 
 patchedDependencies:
+  next: c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b
   railway: ae82e735058108483939c04fb4af5e1f5feb6180ff6d056d5a6dd6db99a63f98
 
 importers:
@@ -20,7 +21,7 @@ importers:
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/passkey':
         specifier: ^1.6.23
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -53,7 +54,7 @@ importers:
         version: 19.1.0-rc.3
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
+        version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -71,10 +72,10 @@ importers:
         version: 1.24.0(react@19.2.7)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: ^2.9.0
-        version: 2.9.0(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.9.0(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -3841,14 +3842,14 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)':
+  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))(nanostores@1.4.0)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.2
-      better-auth: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
+      better-auth: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
       better-call: 1.3.7(zod@4.4.3)
       nanostores: 1.4.0
       zod: 4.4.3
@@ -4870,7 +4871,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.41: {}
 
-  better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
+  better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0))
@@ -4892,7 +4893,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)
-      next: 16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       pg: 8.22.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -5674,7 +5675,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -5711,12 +5712,12 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nuqs@2.9.0(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  nuqs@2.9.0(next@16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.7
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(patch_hash=c5770353f6185f8187975cd3629321f6d70ab819d5779c1c1ef779a34309924b)(@babel/core@7.29.7)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   object-assign@4.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   protobufjs: true
   sharp: true
 patchedDependencies:
+  next: patches/next.patch
   railway: patches/railway.patch
 
 overrides:


### PR DESCRIPTION
## What

- Removes the `experimental.appNewScrollHandler` flag from `next.config.ts`.
- Adds a `pnpm patch` for `next` fixing two scroll-handler bugs that left client-side navigations into detail routes scrolled down.

## Root cause

Two distinct bugs in Next's App Router scroll handling, both producing "arrive scrolled down":

1. **Head-hoisted links kill the segment walk** (legacy handler): the handler locates the navigated segment via `findDOMNode`; when the segment's first node is a stylesheet `<link>` hoisted into `<head>`, the sibling walk dies inside `<head>` and it silently never scrolls. The patch restarts the walk from `<body>`.

2. **Early-exit fossilizes a clamped scroll offset** (BOTH handlers — this is why toggling `appNewScrollHandler` never fixed it): when the destination's loading skeleton is barely taller than the viewport, the browser clamps the retained scroll to less than the segment's document offset (~80px of header + padding). The segment's top edge is then technically visible, the handler's `topOfElementInViewport` early-exit declares "no scroll needed", and it consumes the navigation's one scroll flag — so when the real content streams in, the offset is fossilized. Screen-size dependent: needs `0 < skeleton height − viewport height < segment offset`. The person skeleton at 1480×864 leaves exactly 62px, which is why person pages broke around ~1500px-wide windows while movie/tv (tall backdrop skeletons) never hit the window. Needs streaming latency to reproduce, which is why it only showed on deployed environments. The patch allows the early-exit only when the page is already at the top.

## Verification

- Deterministic repro (throttled connection + 1480×864, `/tv/555` → `/person/29685`): stuck at y=62 before, lands at y=0 after.
- `e2e/detail-scroll.spec.ts`: 10/10 with `--repeat-each=2` against a prod build; new clamp-window regression test fails against the previous patch version and passes with the fix.
- Viewport sweep (1280×720 → 2560×1440) all land at top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)