### PR TITLE
✨ Stream provider filter for all lists

### DIFF
--- a/src/app/lists/[id]/list-details-content.tsx
+++ b/src/app/lists/[id]/list-details-content.tsx
@@ -1,25 +1,27 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, GripVertical } from 'lucide-react';
 import Link from 'next/link';
-import { parseAsInteger, useQueryStates } from 'nuqs';
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
 import { useState } from 'react';
 
 import { DeleteListButton } from '@/components/delete-list-button';
 import { EditListDialog } from '@/components/edit-list-dialog';
 import { ListItemsGrid } from '@/components/list-items-grid';
 import { PaginationControls } from '@/components/pagination-controls';
+import { ReorderButton } from '@/components/reorder-button';
 import SectionTitle from '@/components/section-title';
-import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import WatchProviderFilter from '@/components/watch-provider-filter';
 import { useReorderableItems } from '@/hooks/use-reorderable-items';
 import { ITEMS_PER_PAGE } from '@/lib/config';
 import { moveListItem } from '@/lib/lists';
 import { queryKeys } from '@/lib/query-keys';
+import { activeWatchProviderFilter } from '@/lib/watch-provider-search-params';
 import { MovieDetails } from '@/types/movie';
 import { PersonDetails } from '@/types/person';
 import { TvDetails } from '@/types/tv-show';
+import type { WatchProvider } from '@/types/watch-provider';
 
 export type ListItem =
   | (MovieDetails & { resourceType: 'movie'; listItemId: string })
@@ -41,7 +43,14 @@ type ListDetailsData = {
 type ListDetailsContentProps = {
   listId: string;
   userId?: string;
-  fetchListDetailsAction: (listId: string, page: number) => Promise<ListDetailsData>;
+  fetchListDetailsAction: (
+    listId: string,
+    page: number,
+    watchProviders?: number[],
+    watchRegion?: string,
+  ) => Promise<ListDetailsData>;
+  watchProviders: WatchProvider[];
+  userRegion: string;
 };
 
 /**
@@ -52,11 +61,15 @@ export function ListDetailsContent({
   listId,
   userId,
   fetchListDetailsAction,
+  watchProviders,
+  userRegion,
 }: ListDetailsContentProps) {
   // Use nuqs to manage URL state
   const [urlState] = useQueryStates(
     {
       page: parseAsInteger.withDefault(1),
+      with_watch_providers: parseAsArrayOf(parseAsInteger).withDefault([]),
+      watch_region: parseAsString.withDefault(userRegion),
     },
     {
       history: 'push',
@@ -65,9 +78,17 @@ export function ListDetailsContent({
 
   const page = urlState.page;
 
+  // Normalized exactly like the server shell computes them, so the query key
+  // matches the prefetch after hydration.
+  const { activeProviders, activeRegion } = activeWatchProviderFilter(
+    urlState.with_watch_providers,
+    urlState.watch_region,
+  );
+  const isProviderFiltered = activeProviders !== undefined;
+
   const { data: list, isLoading } = useQuery({
-    queryKey: queryKeys.lists.detail(listId, page),
-    queryFn: () => fetchListDetailsAction(listId, page),
+    queryKey: queryKeys.lists.detail(listId, page, activeProviders, activeRegion),
+    queryFn: () => fetchListDetailsAction(listId, page, activeProviders, activeRegion),
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 30, // 30 minutes
   });
@@ -76,7 +97,16 @@ export function ListDetailsContent({
     return <ListDetailsSkeleton />;
   }
 
-  return <ListDetailsView list={list} page={page} userId={userId} />;
+  return (
+    <ListDetailsView
+      list={list}
+      page={page}
+      userId={userId}
+      watchProviders={watchProviders}
+      userRegion={userRegion}
+      isProviderFiltered={isProviderFiltered}
+    />
+  );
 }
 
 function ListDetailsSkeleton() {
@@ -103,9 +133,19 @@ interface ListDetailsViewProps {
   list: ListDetailsData;
   page: number;
   userId?: string;
+  watchProviders: WatchProvider[];
+  userRegion: string;
+  isProviderFiltered: boolean;
 }
 
-function ListDetailsView({ list, page, userId }: ListDetailsViewProps) {
+function ListDetailsView({
+  list,
+  page,
+  userId,
+  watchProviders,
+  userRegion,
+  isProviderFiltered,
+}: ListDetailsViewProps) {
   const [isEditing, setIsEditing] = useState(false);
   const queryClient = useQueryClient();
 
@@ -130,27 +170,67 @@ function ListDetailsView({ list, page, userId }: ListDetailsViewProps) {
         itemCount={list.itemCount}
         isEditing={isEditing}
         onToggleEditing={() => setIsEditing((value) => !value)}
+        watchProviders={watchProviders}
+        userRegion={userRegion}
+        isProviderFiltered={isProviderFiltered}
       />
 
-      {list.itemCount === 0 ? (
-        <EmptyListState emoji={list.emoji} />
-      ) : (
-        <ListItemsGrid
-          items={localItems}
-          offset={offset}
-          itemCount={list.itemCount}
-          isPending={isPending}
-          editing={isEditing}
-          onMove={move}
-          userId={userId}
-          listId={list.id}
-        />
-      )}
+      <ListDetailsBody
+        list={list}
+        items={localItems}
+        offset={offset}
+        isPending={isPending}
+        isEditing={isEditing && !isProviderFiltered}
+        isProviderFiltered={isProviderFiltered}
+        onMove={move}
+        userId={userId}
+      />
 
       {list.itemCount > 0 && list.totalPages > 1 && (
         <PaginationControls totalPages={list.totalPages} pageType="lists" />
       )}
     </div>
+  );
+}
+
+function ListDetailsBody({
+  list,
+  items,
+  offset,
+  isPending,
+  isEditing,
+  isProviderFiltered,
+  onMove,
+  userId,
+}: {
+  list: ListDetailsData;
+  items: ListItem[];
+  offset: number;
+  isPending: boolean;
+  isEditing: boolean;
+  isProviderFiltered: boolean;
+  onMove: (id: string, toIndex: number) => void;
+  userId?: string;
+}) {
+  if (list.itemCount === 0) {
+    return <EmptyListState emoji={list.emoji} />;
+  }
+
+  if (items.length === 0 && isProviderFiltered) {
+    return <FilteredEmptyListState emoji={list.emoji} />;
+  }
+
+  return (
+    <ListItemsGrid
+      items={items}
+      offset={offset}
+      itemCount={list.itemCount}
+      isPending={isPending}
+      editing={isEditing}
+      onMove={onMove}
+      userId={userId}
+      listId={list.id}
+    />
   );
 }
 
@@ -162,6 +242,9 @@ interface ListDetailsHeaderProps {
   itemCount: number;
   isEditing: boolean;
   onToggleEditing: () => void;
+  watchProviders: WatchProvider[];
+  userRegion: string;
+  isProviderFiltered: boolean;
 }
 
 function ListDetailsHeader({
@@ -172,31 +255,20 @@ function ListDetailsHeader({
   itemCount,
   isEditing,
   onToggleEditing,
+  watchProviders,
+  userRegion,
+  isProviderFiltered,
 }: ListDetailsHeaderProps) {
   return (
     <div className="mb-8">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
         <SectionTitle>{listName}</SectionTitle>
-        <div className="flex items-center gap-2">
-          {itemCount > 0 && (
-            <Button
-              variant={isEditing ? 'default' : 'secondary'}
-              size="sm"
-              onClick={onToggleEditing}
-              aria-pressed={isEditing}
-            >
-              {isEditing ? (
-                <>
-                  <Check className="h-4 w-4" />
-                  Done
-                </>
-              ) : (
-                <>
-                  <GripVertical className="h-4 w-4" />
-                  Reorder items
-                </>
-              )}
-            </Button>
+        <div className="flex flex-wrap items-end gap-2">
+          {/* Reordering a provider-filtered view is disabled: the visible rows
+              are a non-contiguous slice, so page offsets no longer map to
+              positions in the full manual order. */}
+          {itemCount > 0 && !isProviderFiltered && (
+            <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
           <EditListDialog
             listId={listId}
@@ -210,8 +282,23 @@ function ListDetailsHeader({
             itemCount={itemCount}
             redirectAfterDelete={true}
           />
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} />
         </div>
       </div>
+    </div>
+  );
+}
+
+function FilteredEmptyListState({ emoji }: { emoji: string }) {
+  return (
+    <div className="py-12 text-center">
+      <div className="mb-4 text-6xl opacity-50">{emoji}</div>
+      <h2 className="mb-2 text-xl font-semibold">
+        Nothing in this list is on the selected watch providers
+      </h2>
+      <p className="mb-6 text-zinc-400">
+        Try other watch providers or clear the filter to see everything
+      </p>
     </div>
   );
 }

--- a/src/app/lists/[id]/list-details-content.tsx
+++ b/src/app/lists/[id]/list-details-content.tsx
@@ -279,10 +279,10 @@ function ListDetailsHeader({
           {/* Reordering a provider-filtered view is disabled: the visible rows
               are a non-contiguous slice, so page offsets no longer map to
               positions in the full manual order. */}
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
           {itemCount > 0 && !isProviderFiltered && (
             <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
-          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/app/lists/[id]/list-details-content.tsx
+++ b/src/app/lists/[id]/list-details-content.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 
 import { DeleteListButton } from '@/components/delete-list-button';
 import { EditListDialog } from '@/components/edit-list-dialog';
+import { ListErrorState } from '@/components/list-error-state';
 import { ListItemsGrid } from '@/components/list-items-grid';
 import { PaginationControls } from '@/components/pagination-controls';
 import { ReorderButton } from '@/components/reorder-button';
@@ -86,12 +87,22 @@ export function ListDetailsContent({
   );
   const isProviderFiltered = activeProviders !== undefined;
 
-  const { data: list, isLoading } = useQuery({
+  const {
+    data: list,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: queryKeys.lists.detail(listId, page, activeProviders, activeRegion),
     queryFn: () => fetchListDetailsAction(listId, page, activeProviders, activeRegion),
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 30, // 30 minutes
   });
+
+  // Without this, a failed fetch (e.g. a provider availability outage) leaves
+  // the skeleton up forever.
+  if (isError) {
+    return <ListErrorState />;
+  }
 
   if (isLoading || !list) {
     return <ListDetailsSkeleton />;
@@ -261,8 +272,19 @@ function ListDetailsHeader({
 }: ListDetailsHeaderProps) {
   return (
     <div className="mb-8 space-y-4">
+      <SectionTitle>{listName}</SectionTitle>
+
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <SectionTitle>{listName}</SectionTitle>
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Reordering a provider-filtered view is disabled: the visible rows
+              are a non-contiguous slice, so page offsets no longer map to
+              positions in the full manual order. */}
+          {itemCount > 0 && !isProviderFiltered && (
+            <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
+          )}
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
+        </div>
+
         <div className="flex items-center gap-2">
           <EditListDialog
             listId={listId}
@@ -277,16 +299,6 @@ function ListDetailsHeader({
             redirectAfterDelete={true}
           />
         </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2">
-        {/* Reordering a provider-filtered view is disabled: the visible rows
-            are a non-contiguous slice, so page offsets no longer map to
-            positions in the full manual order. */}
-        {itemCount > 0 && !isProviderFiltered && (
-          <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
-        )}
-        <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
       </div>
     </div>
   );

--- a/src/app/lists/[id]/list-details-content.tsx
+++ b/src/app/lists/[id]/list-details-content.tsx
@@ -260,17 +260,10 @@ function ListDetailsHeader({
   isProviderFiltered,
 }: ListDetailsHeaderProps) {
   return (
-    <div className="mb-8">
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="mb-8 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <SectionTitle>{listName}</SectionTitle>
-        <div className="flex flex-wrap items-center gap-2">
-          {/* Reordering a provider-filtered view is disabled: the visible rows
-              are a non-contiguous slice, so page offsets no longer map to
-              positions in the full manual order. */}
-          {itemCount > 0 && !isProviderFiltered && (
-            <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
-          )}
-          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
+        <div className="flex items-center gap-2">
           <EditListDialog
             listId={listId}
             listName={listName}
@@ -284,6 +277,16 @@ function ListDetailsHeader({
             redirectAfterDelete={true}
           />
         </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Reordering a provider-filtered view is disabled: the visible rows
+            are a non-contiguous slice, so page offsets no longer map to
+            positions in the full manual order. */}
+        {itemCount > 0 && !isProviderFiltered && (
+          <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
+        )}
+        <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
       </div>
     </div>
   );

--- a/src/app/lists/[id]/list-details-content.tsx
+++ b/src/app/lists/[id]/list-details-content.tsx
@@ -263,13 +263,14 @@ function ListDetailsHeader({
     <div className="mb-8">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
         <SectionTitle>{listName}</SectionTitle>
-        <div className="flex flex-wrap items-end gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* Reordering a provider-filtered view is disabled: the visible rows
               are a non-contiguous slice, so page offsets no longer map to
               positions in the full manual order. */}
           {itemCount > 0 && !isProviderFiltered && (
             <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
           <EditListDialog
             listId={listId}
             listName={listName}
@@ -282,7 +283,6 @@ function ListDetailsHeader({
             itemCount={itemCount}
             redirectAfterDelete={true}
           />
-          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} />
         </div>
       </div>
     </div>

--- a/src/app/lists/[id]/page.tsx
+++ b/src/app/lists/[id]/page.tsx
@@ -5,6 +5,11 @@ import { getUser } from '@/lib/auth-server';
 import { getListDetailsWithResources, getOwnedCustomList } from '@/lib/lists';
 import { getQueryClient } from '@/lib/query-client';
 import { queryKeys } from '@/lib/query-keys';
+import { getWatchProviderFilterContext } from '@/lib/watch-provider-filter-context';
+import {
+  activeWatchProviderFilter,
+  loadWatchProviderSearchParams,
+} from '@/lib/watch-provider-search-params';
 
 import { ListDetailsContent } from './list-details-content';
 
@@ -18,12 +23,27 @@ async function assertOwnedCustomList(listId: string) {
   }
 }
 
+/** Canonical URL for a list page, keeping an active provider filter intact. */
+function canonicalListPageUrl(
+  listId: string,
+  page: number,
+  watchProviders?: number[],
+  watchRegion?: string,
+) {
+  const params = new URLSearchParams({ page: String(page) });
+  if (watchProviders && watchRegion) {
+    params.set('with_watch_providers', watchProviders.join(','));
+    params.set('watch_region', watchRegion);
+  }
+  return `/lists/${listId}?${params.toString()}`;
+}
+
 export default async function ListDetailsPage({
   params,
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string; with_watch_providers?: string; watch_region?: string }>;
 }) {
   const user = await getUser();
 
@@ -32,8 +52,18 @@ export default async function ListDetailsPage({
   }
 
   const { id } = await params;
-  const { page: pageParam } = await searchParams;
-  const page = Number(pageParam ?? '1');
+  const search = await searchParams;
+  const page = Number(search.page ?? '1');
+
+  const { with_watch_providers, watch_region } = loadWatchProviderSearchParams(search);
+  const { userRegion, availableWatchProviders } = await getWatchProviderFilterContext(watch_region);
+
+  // Normalized exactly like the client content computes them, so the
+  // prefetched query key matches after hydration.
+  const { activeProviders, activeRegion } = activeWatchProviderFilter(
+    with_watch_providers,
+    userRegion,
+  );
 
   await assertOwnedCustomList(id);
 
@@ -41,13 +71,13 @@ export default async function ListDetailsPage({
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({
-    queryKey: queryKeys.lists.detail(id, page),
+    queryKey: queryKeys.lists.detail(id, page, activeProviders, activeRegion),
     queryFn: async () => {
-      const result = await getListDetailsWithResources(id, page);
+      const result = await getListDetailsWithResources(id, page, activeProviders, activeRegion);
 
       // If requested page is beyond the last, canonicalize the URL
       if (result.totalPages > 0 && page > result.totalPages) {
-        redirect(`/lists/${id}?page=${result.totalPages}`);
+        redirect(canonicalListPageUrl(id, result.totalPages, activeProviders, activeRegion));
       }
 
       return result;
@@ -57,14 +87,25 @@ export default async function ListDetailsPage({
   });
 
   // Create a server action to fetch list details
-  async function fetchListDetails(listId: string, page: number) {
+  async function fetchListDetails(
+    listId: string,
+    page: number,
+    watchProviders?: number[],
+    watchRegion?: string,
+  ) {
     'use server';
-    return getListDetailsWithResources(listId, page);
+    return getListDetailsWithResources(listId, page, watchProviders, watchRegion);
   }
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <ListDetailsContent listId={id} userId={user?.id} fetchListDetailsAction={fetchListDetails} />
+      <ListDetailsContent
+        listId={id}
+        userId={user?.id}
+        fetchListDetailsAction={fetchListDetails}
+        watchProviders={availableWatchProviders}
+        userRegion={userRegion}
+      />
     </HydrationBoundary>
   );
 }

--- a/src/components/list-error-state.tsx
+++ b/src/components/list-error-state.tsx
@@ -1,0 +1,10 @@
+/** Shown when a list query fails (e.g. provider availability lookups). */
+export function ListErrorState() {
+  return (
+    <div className="py-12 text-center">
+      <div className="mb-4 text-6xl opacity-50">⚠️</div>
+      <h2 className="mb-2 text-xl font-semibold">Couldn&apos;t load this list</h2>
+      <p className="text-zinc-400">Something went wrong on our end. Refresh the page to retry.</p>
+    </div>
+  );
+}

--- a/src/components/reorder-button.tsx
+++ b/src/components/reorder-button.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Check, GripVertical } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+type ReorderButtonProps = {
+  isEditing: boolean;
+  onToggleEditing: () => void;
+};
+
+/** Toggles a list page's manual-reorder mode. */
+export function ReorderButton({ isEditing, onToggleEditing }: ReorderButtonProps) {
+  return (
+    <Button
+      variant={isEditing ? 'default' : 'secondary'}
+      size="sm"
+      onClick={onToggleEditing}
+      aria-pressed={isEditing}
+    >
+      {isEditing ? (
+        <>
+          <Check className="h-4 w-4" />
+          Done
+        </>
+      ) : (
+        <>
+          <GripVertical className="h-4 w-4" />
+          Reorder items
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/components/system-list-content.tsx
+++ b/src/components/system-list-content.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
 import { useState } from 'react';
 
+import { ListErrorState } from '@/components/list-error-state';
 import { ListItemsGrid } from '@/components/list-items-grid';
 import MediaTypeSelector from '@/components/media-type-selector';
 import { PaginationControls } from '@/components/pagination-controls';
@@ -118,7 +119,11 @@ export function SystemListContent({
   );
   const isProviderFiltered = activeProviders !== undefined;
 
-  const { data: paginatedData, isLoading } = useQuery({
+  const {
+    data: paginatedData,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: queryKeys[listType].list(mediaType, page, activeProviders, activeRegion),
     queryFn: () =>
       getSystemListWithResourceDetailsPaginated(
@@ -181,6 +186,7 @@ export function SystemListContent({
         mediaType={mediaType}
         userId={userId}
         isLoading={isLoading}
+        isError={isError}
         isAllEmpty={totalItems === 0}
         isProviderFiltered={isProviderFiltered}
         items={localItems}
@@ -279,6 +285,7 @@ function SystemListBody({
   mediaType,
   userId,
   isLoading,
+  isError,
   isAllEmpty,
   isProviderFiltered,
   items,
@@ -293,6 +300,7 @@ function SystemListBody({
   mediaType: 'movie' | 'tv';
   userId?: string;
   isLoading: boolean;
+  isError: boolean;
   isAllEmpty: boolean;
   isProviderFiltered: boolean;
   items: SystemListItem[];
@@ -305,6 +313,10 @@ function SystemListBody({
 }) {
   if (isLoading) {
     return <PosterSkeletonGrid />;
+  }
+
+  if (isError) {
+    return <ListErrorState />;
   }
 
   if (items.length === 0) {
@@ -330,9 +342,17 @@ function SystemListBody({
         userId={userId}
       />
 
-      {totalPages > 1 && <PaginationControls totalPages={totalPages} pageType={listType} />}
+      <ListPagination totalPages={totalPages} pageType={listType} />
     </>
   );
+}
+
+function ListPagination({ totalPages, pageType }: { totalPages: number; pageType: SystemListType }) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return <PaginationControls totalPages={totalPages} pageType={pageType} />;
 }
 
 function emptyStateCopy(

--- a/src/components/system-list-content.tsx
+++ b/src/components/system-list-content.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, GripVertical } from 'lucide-react';
 import Link from 'next/link';
-import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
 import { useState } from 'react';
 
 import { ListItemsGrid } from '@/components/list-items-grid';
 import MediaTypeSelector from '@/components/media-type-selector';
 import { PaginationControls } from '@/components/pagination-controls';
 import { PosterSkeletonGrid } from '@/components/poster-skeleton-grid';
+import { ReorderButton } from '@/components/reorder-button';
 import SectionTitle from '@/components/section-title';
-import { Button } from '@/components/ui/button';
+import WatchProviderFilter from '@/components/watch-provider-filter';
 import { useReorderableItems } from '@/hooks/use-reorderable-items';
 import { ITEMS_PER_PAGE } from '@/lib/config';
 import { moveListItem } from '@/lib/lists';
@@ -22,6 +22,8 @@ import {
   type SystemListItem,
 } from '@/lib/system-list-queries';
 import type { SystemListType } from '@/lib/validations';
+import { activeWatchProviderFilter } from '@/lib/watch-provider-search-params';
+import type { WatchProvider } from '@/types/watch-provider';
 
 const CONTENT_COPY: Record<
   SystemListType,
@@ -78,6 +80,8 @@ const EMPTY_RESULT: { items: SystemListItem[]; totalPages: number } = {
 type SystemListContentProps = {
   listType: SystemListType;
   userId?: string;
+  watchProviders: WatchProvider[];
+  userRegion: string;
 };
 
 /**
@@ -85,11 +89,18 @@ type SystemListContentProps = {
  * React Query. Uses nuqs to manage URL state, which automatically triggers
  * React Query refetches.
  */
-export function SystemListContent({ listType, userId }: SystemListContentProps) {
+export function SystemListContent({
+  listType,
+  userId,
+  watchProviders,
+  userRegion,
+}: SystemListContentProps) {
   const [urlState] = useQueryStates(
     {
       mediaType: parseAsString.withDefault('movie'),
       page: parseAsInteger.withDefault(1),
+      with_watch_providers: parseAsArrayOf(parseAsInteger).withDefault([]),
+      watch_region: parseAsString.withDefault(userRegion),
     },
     {
       history: 'push',
@@ -99,9 +110,24 @@ export function SystemListContent({ listType, userId }: SystemListContentProps) 
   const mediaType = urlState.mediaType as 'movie' | 'tv';
   const page = urlState.page;
 
+  // Normalized exactly like the server shell computes them, so the query key
+  // matches the prefetch after hydration.
+  const { activeProviders, activeRegion } = activeWatchProviderFilter(
+    urlState.with_watch_providers,
+    urlState.watch_region,
+  );
+  const isProviderFiltered = activeProviders !== undefined;
+
   const { data: paginatedData, isLoading } = useQuery({
-    queryKey: queryKeys[listType].list(mediaType, page),
-    queryFn: () => getSystemListWithResourceDetailsPaginated(listType, mediaType, page),
+    queryKey: queryKeys[listType].list(mediaType, page, activeProviders, activeRegion),
+    queryFn: () =>
+      getSystemListWithResourceDetailsPaginated(
+        listType,
+        mediaType,
+        page,
+        activeProviders,
+        activeRegion,
+      ),
     ...SYSTEM_LIST_QUERY_TIMES,
   });
 
@@ -145,6 +171,9 @@ export function SystemListContent({ listType, userId }: SystemListContentProps) 
         totalTvShows={totalTvShows}
         isEditing={isEditing}
         onToggleEditing={() => setIsEditing((value) => !value)}
+        watchProviders={watchProviders}
+        userRegion={userRegion}
+        isProviderFiltered={isProviderFiltered}
       />
 
       <SystemListBody
@@ -153,11 +182,12 @@ export function SystemListContent({ listType, userId }: SystemListContentProps) 
         userId={userId}
         isLoading={isLoading}
         isAllEmpty={totalItems === 0}
+        isProviderFiltered={isProviderFiltered}
         items={localItems}
         totalPages={totalPages}
         itemCount={totalForMedia}
         offset={offset}
-        isEditing={isEditing}
+        isEditing={isEditing && !isProviderFiltered}
         isPending={isPending}
         onMove={move}
       />
@@ -172,6 +202,9 @@ function SystemListHeader({
   totalTvShows,
   isEditing,
   onToggleEditing,
+  watchProviders,
+  userRegion,
+  isProviderFiltered,
 }: {
   listType: SystemListType;
   mediaType: 'movie' | 'tv';
@@ -179,9 +212,11 @@ function SystemListHeader({
   totalTvShows: number;
   isEditing: boolean;
   onToggleEditing: () => void;
+  watchProviders: WatchProvider[];
+  userRegion: string;
+  isProviderFiltered: boolean;
 }) {
   const totalItems = totalMovies + totalTvShows;
-  const mediaTypeCount = mediaType === 'movie' ? totalMovies : totalTvShows;
 
   return (
     <div className="mb-8">
@@ -189,54 +224,53 @@ function SystemListHeader({
         <SectionTitle>{CONTENT_COPY[listType].title}</SectionTitle>
       </div>
 
-      <div className="flex flex-col gap-4 @2xl:flex-row @2xl:items-center @2xl:justify-between">
-        <div className="flex items-center gap-2">
-          <p className="text-zinc-400">
-            {formatCount(mediaTypeCount, MEDIA_META[mediaType].countNoun)}{' '}
-            {CONTENT_COPY[listType].countNoun}
-          </p>
-          {totalItems > 0 && (
-            <span className="text-zinc-500">• Total: {formatCount(totalItems, 'item')}</span>
-          )}
-        </div>
+      <div className="flex flex-col gap-4 @2xl:flex-row @2xl:items-end @2xl:justify-between">
+        <SystemListCounts
+          listType={listType}
+          mediaType={mediaType}
+          totalMovies={totalMovies}
+          totalTvShows={totalTvShows}
+        />
 
-        <div className="flex items-center gap-2">
-          {totalItems > 0 && (
+        <div className="flex flex-wrap items-end gap-2">
+          {/* Reordering a provider-filtered view is disabled: the visible rows
+              are a non-contiguous slice, so page offsets no longer map to
+              positions in the full manual order. */}
+          {totalItems > 0 && !isProviderFiltered && (
             <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
           <MediaTypeSelector currentMediaType={mediaType} />
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} />
         </div>
       </div>
     </div>
   );
 }
 
-function ReorderButton({
-  isEditing,
-  onToggleEditing,
+function SystemListCounts({
+  listType,
+  mediaType,
+  totalMovies,
+  totalTvShows,
 }: {
-  isEditing: boolean;
-  onToggleEditing: () => void;
+  listType: SystemListType;
+  mediaType: 'movie' | 'tv';
+  totalMovies: number;
+  totalTvShows: number;
 }) {
+  const totalItems = totalMovies + totalTvShows;
+  const mediaTypeCount = mediaType === 'movie' ? totalMovies : totalTvShows;
+
   return (
-    <Button
-      variant={isEditing ? 'default' : 'secondary'}
-      size="sm"
-      onClick={onToggleEditing}
-      aria-pressed={isEditing}
-    >
-      {isEditing ? (
-        <>
-          <Check className="h-4 w-4" />
-          Done
-        </>
-      ) : (
-        <>
-          <GripVertical className="h-4 w-4" />
-          Reorder items
-        </>
+    <div className="flex items-center gap-2">
+      <p className="text-zinc-400">
+        {formatCount(mediaTypeCount, MEDIA_META[mediaType].countNoun)}{' '}
+        {CONTENT_COPY[listType].countNoun}
+      </p>
+      {totalItems > 0 && (
+        <span className="text-zinc-500">• Total: {formatCount(totalItems, 'item')}</span>
       )}
-    </Button>
+    </div>
   );
 }
 
@@ -246,6 +280,7 @@ function SystemListBody({
   userId,
   isLoading,
   isAllEmpty,
+  isProviderFiltered,
   items,
   totalPages,
   itemCount,
@@ -259,6 +294,7 @@ function SystemListBody({
   userId?: string;
   isLoading: boolean;
   isAllEmpty: boolean;
+  isProviderFiltered: boolean;
   items: SystemListItem[];
   totalPages: number;
   itemCount: number;
@@ -272,7 +308,14 @@ function SystemListBody({
   }
 
   if (items.length === 0) {
-    return <EmptyState listType={listType} mediaType={mediaType} isAllEmpty={isAllEmpty} />;
+    return (
+      <EmptyState
+        listType={listType}
+        mediaType={mediaType}
+        isAllEmpty={isAllEmpty}
+        isProviderFiltered={isProviderFiltered}
+      />
+    );
   }
 
   return (
@@ -292,27 +335,47 @@ function SystemListBody({
   );
 }
 
+function emptyStateCopy(
+  listType: SystemListType,
+  mediaType: 'movie' | 'tv',
+  isAllEmpty: boolean,
+  isProviderFiltered: boolean,
+) {
+  const copy = CONTENT_COPY[listType];
+  const meta = MEDIA_META[mediaType];
+
+  if (isProviderFiltered) {
+    return {
+      title: `No ${meta.label} on the selected watch providers`,
+      hint: 'Try other watch providers or clear the filter to see everything',
+    };
+  }
+
+  return {
+    title: isAllEmpty ? copy.emptyTitleAll : copy.emptyTitleMedia(meta.label),
+    hint: isAllEmpty ? copy.emptyHintAll(meta.label) : copy.emptyHintMedia(meta.label),
+  };
+}
+
 function EmptyState({
   listType,
   mediaType,
   isAllEmpty,
+  isProviderFiltered,
 }: {
   listType: SystemListType;
   mediaType: 'movie' | 'tv';
   isAllEmpty: boolean;
+  isProviderFiltered: boolean;
 }) {
-  const copy = CONTENT_COPY[listType];
   const meta = MEDIA_META[mediaType];
+  const { title, hint } = emptyStateCopy(listType, mediaType, isAllEmpty, isProviderFiltered);
 
   return (
     <div className="py-12 text-center">
       <div className="mb-4 text-6xl opacity-50">{meta.emoji}</div>
-      <h2 className="mb-2 text-xl font-semibold">
-        {isAllEmpty ? copy.emptyTitleAll : copy.emptyTitleMedia(meta.label)}
-      </h2>
-      <p className="mb-6 text-zinc-400">
-        {isAllEmpty ? copy.emptyHintAll(meta.label) : copy.emptyHintMedia(meta.label)}
-      </p>
+      <h2 className="mb-2 text-xl font-semibold">{title}</h2>
+      <p className="mb-6 text-zinc-400">{hint}</p>
       <Link
         href={`/discover?mediaType=${mediaType}`}
         className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"

--- a/src/components/system-list-content.tsx
+++ b/src/components/system-list-content.tsx
@@ -243,10 +243,10 @@ function SystemListHeader({
           {/* Reordering a provider-filtered view is disabled: the visible rows
               are a non-contiguous slice, so page offsets no longer map to
               positions in the full manual order. */}
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
           {totalItems > 0 && !isProviderFiltered && (
             <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
-          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
         </div>
 
         <MediaTypeSelector currentMediaType={mediaType} />

--- a/src/components/system-list-content.tsx
+++ b/src/components/system-list-content.tsx
@@ -232,15 +232,15 @@ function SystemListHeader({
           totalTvShows={totalTvShows}
         />
 
-        <div className="flex flex-wrap items-end gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* Reordering a provider-filtered view is disabled: the visible rows
               are a non-contiguous slice, so page offsets no longer map to
               positions in the full manual order. */}
           {totalItems > 0 && !isProviderFiltered && (
             <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
+          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
           <MediaTypeSelector currentMediaType={mediaType} />
-          <WatchProviderFilter providers={watchProviders} userRegion={userRegion} />
         </div>
       </div>
     </div>

--- a/src/components/system-list-content.tsx
+++ b/src/components/system-list-content.tsx
@@ -225,19 +225,20 @@ function SystemListHeader({
   const totalItems = totalMovies + totalTvShows;
 
   return (
-    <div className="mb-8">
-      <div className="mb-4 flex items-center gap-4">
-        <SectionTitle>{CONTENT_COPY[listType].title}</SectionTitle>
-      </div>
-
-      <div className="flex flex-col gap-4 @2xl:flex-row @2xl:items-end @2xl:justify-between">
+    <div className="mb-8 space-y-4">
+      <div>
+        <div className="mb-2 flex items-center gap-4">
+          <SectionTitle>{CONTENT_COPY[listType].title}</SectionTitle>
+        </div>
         <SystemListCounts
           listType={listType}
           mediaType={mediaType}
           totalMovies={totalMovies}
           totalTvShows={totalTvShows}
         />
+      </div>
 
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap items-center gap-2">
           {/* Reordering a provider-filtered view is disabled: the visible rows
               are a non-contiguous slice, so page offsets no longer map to
@@ -246,8 +247,9 @@ function SystemListHeader({
             <ReorderButton isEditing={isEditing} onToggleEditing={onToggleEditing} />
           )}
           <WatchProviderFilter providers={watchProviders} userRegion={userRegion} compact />
-          <MediaTypeSelector currentMediaType={mediaType} />
         </div>
+
+        <MediaTypeSelector currentMediaType={mediaType} />
       </div>
     </div>
   );

--- a/src/components/system-list-page.tsx
+++ b/src/components/system-list-page.tsx
@@ -10,11 +10,18 @@ import {
   getSystemListWithResourceDetailsPaginated,
 } from '@/lib/system-list-queries';
 import type { SystemListType } from '@/lib/validations';
+import { getWatchProviderFilterContext } from '@/lib/watch-provider-filter-context';
+import {
+  activeWatchProviderFilter,
+  loadWatchProviderSearchParams,
+} from '@/lib/watch-provider-search-params';
 
 export type SystemListPageProps = {
   searchParams: Promise<{
     mediaType?: string;
     page?: string;
+    with_watch_providers?: string;
+    watch_region?: string;
   }>;
 };
 
@@ -37,12 +44,29 @@ export async function SystemListPage({
   const mediaType = (params.mediaType ?? 'movie') as 'movie' | 'tv';
   const page = Number(params.page ?? '1');
 
+  const { with_watch_providers, watch_region } = loadWatchProviderSearchParams(params);
+  const { userRegion, availableWatchProviders } = await getWatchProviderFilterContext(watch_region);
+
+  // Normalized exactly like the client content computes them, so the
+  // prefetched query key matches after hydration.
+  const { activeProviders, activeRegion } = activeWatchProviderFilter(
+    with_watch_providers,
+    userRegion,
+  );
+
   const queryClient = getQueryClient();
 
   await Promise.all([
     queryClient.prefetchQuery({
-      queryKey: queryKeys[listType].list(mediaType, page),
-      queryFn: () => getSystemListWithResourceDetailsPaginated(listType, mediaType, page),
+      queryKey: queryKeys[listType].list(mediaType, page, activeProviders, activeRegion),
+      queryFn: () =>
+        getSystemListWithResourceDetailsPaginated(
+          listType,
+          mediaType,
+          page,
+          activeProviders,
+          activeRegion,
+        ),
       ...SYSTEM_LIST_QUERY_TIMES,
     }),
     queryClient.prefetchQuery({
@@ -59,7 +83,12 @@ export async function SystemListPage({
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <SystemListContent listType={listType} userId={user.id} />
+      <SystemListContent
+        listType={listType}
+        userId={user.id}
+        watchProviders={availableWatchProviders}
+        userRegion={userRegion}
+      />
     </HydrationBoundary>
   );
 }

--- a/src/components/watch-provider-filter.tsx
+++ b/src/components/watch-provider-filter.tsx
@@ -3,7 +3,7 @@
 import { Check, Filter } from 'lucide-react';
 import Image from 'next/image';
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
-import { useState } from 'react';
+import { ComponentProps, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -15,6 +15,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { DEFAULT_REGION } from '@/lib/regions';
+import { cn } from '@/lib/utils';
 import { WatchProvider } from '@/types/watch-provider';
 
 interface WatchProviderFilterProps {
@@ -27,10 +28,20 @@ interface WatchProviderFilterProps {
   compact?: boolean;
 }
 
+// Both triggers spread rest props (and ref) into Button: PopoverTrigger's
+// `render` clones the element with the trigger props (onClick, aria-*), and
+// dropping them leaves a button that never opens the popover.
+type TriggerProps = { selectedCount: number } & ComponentProps<typeof Button>;
+
 /** Discover's filter-panel trigger: labeled, full-width field. */
-function PanelTrigger({ selectedCount }: { selectedCount: number }) {
+function PanelTrigger({ selectedCount, className, ...props }: TriggerProps) {
   return (
-    <Button variant="outline" className="w-full justify-between" id="watch-providers">
+    <Button
+      {...props}
+      variant="outline"
+      className={cn('w-full justify-between', className)}
+      id="watch-providers"
+    >
       <Filter className="mr-2 h-4 w-4" />
       {selectedCount > 0
         ? `${selectedCount} provider${selectedCount === 1 ? '' : 's'} selected`
@@ -40,9 +51,9 @@ function PanelTrigger({ selectedCount }: { selectedCount: number }) {
 }
 
 /** List-header trigger: compact button with a count badge when active. */
-function CompactTrigger({ selectedCount }: { selectedCount: number }) {
+function CompactTrigger({ selectedCount, ...props }: TriggerProps) {
   return (
-    <Button variant="outline" size="sm">
+    <Button {...props} variant="outline" size="sm">
       <Filter className="h-4 w-4" />
       Providers
       {selectedCount > 0 && (

--- a/src/components/watch-provider-filter.tsx
+++ b/src/components/watch-provider-filter.tsx
@@ -20,6 +20,38 @@ import { WatchProvider } from '@/types/watch-provider';
 interface WatchProviderFilterProps {
   providers: WatchProvider[];
   userRegion: string;
+  /**
+   * Renders a small labelless trigger that sits inline with `size="sm"`
+   * header buttons (list pages) instead of the labeled panel field (discover).
+   */
+  compact?: boolean;
+}
+
+/** Discover's filter-panel trigger: labeled, full-width field. */
+function PanelTrigger({ selectedCount }: { selectedCount: number }) {
+  return (
+    <Button variant="outline" className="w-full justify-between" id="watch-providers">
+      <Filter className="mr-2 h-4 w-4" />
+      {selectedCount > 0
+        ? `${selectedCount} provider${selectedCount === 1 ? '' : 's'} selected`
+        : 'Select watch providers'}
+    </Button>
+  );
+}
+
+/** List-header trigger: compact button with a count badge when active. */
+function CompactTrigger({ selectedCount }: { selectedCount: number }) {
+  return (
+    <Button variant="outline" size="sm">
+      <Filter className="h-4 w-4" />
+      Providers
+      {selectedCount > 0 && (
+        <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+          {selectedCount}
+        </span>
+      )}
+    </Button>
+  );
 }
 
 /**
@@ -29,7 +61,11 @@ interface WatchProviderFilterProps {
  * Uses OR logic - shows content available on ANY of the selected providers.
  * The selected providers are applied to URL query parameters for filtering results.
  */
-export default function WatchProviderFilter({ providers, userRegion }: WatchProviderFilterProps) {
+export default function WatchProviderFilter({
+  providers,
+  userRegion,
+  compact = false,
+}: WatchProviderFilterProps) {
   const [{ with_watch_providers }, setParams] = useQueryStates({
     with_watch_providers: parseAsArrayOf(parseAsInteger).withDefault([]),
     watch_region: parseAsString.withDefault(DEFAULT_REGION),
@@ -72,22 +108,17 @@ export default function WatchProviderFilter({ providers, userRegion }: WatchProv
 
   const selectedCount = selectedProviders.length;
 
-  return (
-    <div className="min-w-54">
-      <Label htmlFor="watch-providers" className="mb-2 flex justify-end @3xl:self-end">
-        Watch Providers
-      </Label>
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger
-          render={
-            <Button variant="outline" className="w-full justify-between" id="watch-providers">
-              <Filter className="mr-2 h-4 w-4" />
-              {selectedCount > 0
-                ? `${selectedCount} provider${selectedCount === 1 ? '' : 's'} selected`
-                : 'Select watch providers'}
-            </Button>
-          }
-        />
+  const popover = (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger
+        render={
+          compact ? (
+            <CompactTrigger selectedCount={selectedCount} />
+          ) : (
+            <PanelTrigger selectedCount={selectedCount} />
+          )
+        }
+      />
         <PopoverContent
           align="end"
           side="bottom"
@@ -151,7 +182,19 @@ export default function WatchProviderFilter({ providers, userRegion }: WatchProv
             )}
           </div>
         </PopoverContent>
-      </Popover>
+    </Popover>
+  );
+
+  if (compact) {
+    return popover;
+  }
+
+  return (
+    <div className="min-w-54">
+      <Label htmlFor="watch-providers" className="mb-2 flex justify-end @3xl:self-end">
+        Watch Providers
+      </Label>
+      {popover}
     </div>
   );
 }

--- a/src/components/watch-provider-filter.tsx
+++ b/src/components/watch-provider-filter.tsx
@@ -131,7 +131,7 @@ export default function WatchProviderFilter({
         }
       />
         <PopoverContent
-          align="end"
+          align={compact ? 'start' : 'end'}
           side="bottom"
           sideOffset={10}
           className="max-h-[60dvh] overflow-auto"

--- a/src/lib/lists.test.ts
+++ b/src/lib/lists.test.ts
@@ -15,6 +15,13 @@ vi.mock('next/cache', () => ({
   cacheTag: vi.fn(),
 }));
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+vi.mock('@/lib/movies', () => ({ getMovieDetails: vi.fn(), getMovieWatchProviders: vi.fn() }));
+vi.mock('@/lib/tv-shows', () => ({
+  getTvShowDetails: vi.fn(),
+  getTvShowWatchProviders: vi.fn(),
+}));
+vi.mock('@/lib/persons', () => ({ getPersonDetails: vi.fn() }));
+vi.mock('@/lib/imgproxy-url', () => ({ buildProxyImageUrls: vi.fn(() => undefined) }));
 // Run the locked callback against the db mock directly; the real lock needs a
 // live transaction and is covered by ordering-lock.test.ts.
 vi.mock('@/lib/ordering-lock', async (importOriginal) => {
@@ -32,13 +39,16 @@ import {
   revalidateUserSystemListPageCache,
 } from '@/lib/cache-invalidation';
 import { db } from '@/lib/db';
+import { getMovieDetails, getMovieWatchProviders } from '@/lib/movies';
 import { withOrderingLock } from '@/lib/ordering-lock';
+import { getPersonDetails } from '@/lib/persons';
 import { chain } from '@/test/db-chain';
 
 import {
   addToList,
   createList,
   deleteList,
+  getListDetailsWithResources,
   getOwnedCustomList,
   moveListItem,
   moveList,
@@ -198,6 +208,79 @@ describe('moveListItem', () => {
     await moveListItem(UUID, 0, 'movie');
     expect(revalidateUserSystemListPageCache).toHaveBeenCalledWith('user-1', 'watchlist');
     expect(revalidateUserListCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('getListDetailsWithResources with a provider filter', () => {
+  const list = {
+    id: UUID,
+    userId: 'user-1',
+    type: 'custom',
+    name: 'My list',
+    description: null,
+    emoji: '📝',
+    position: 1,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+
+  const itemRows = [
+    { id: 'item-1', listId: UUID, resourceId: 1, resourceType: 'movie', position: 1, createdAt: new Date(0) },
+    { id: 'item-2', listId: UUID, resourceId: 2, resourceType: 'movie', position: 2, createdAt: new Date(0) },
+    { id: 'item-3', listId: UUID, resourceId: 3, resourceType: 'person', position: 3, createdAt: new Date(0) },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(getMovieDetails).mockImplementation(
+      async (movieId: number) => ({ id: movieId, poster_path: null }) as never,
+    );
+    // Movie 1 streams on provider 8 in SE; movie 2 streams nowhere.
+    vi.mocked(getMovieWatchProviders).mockImplementation(async (movieId: number) => ({
+      results:
+        movieId === 1
+          ? {
+              SE: {
+                link: 'https://tmdb',
+                flatrate: [
+                  { provider_id: 8, provider_name: 'Netflix', logo_path: '/n.png', display_priority: 1 },
+                ],
+              },
+            }
+          : {},
+    }));
+  });
+
+  it('keeps only streamable items while itemCount stays the unfiltered total', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chain([list]))
+      .mockReturnValueOnce(chain(itemRows));
+
+    const result = await getListDetailsWithResources(UUID, 1, [8], 'SE');
+
+    expect(result.allItems.map((item) => item.id)).toEqual([1]);
+    expect(result.totalItems).toBe(1);
+    expect(result.totalPages).toBe(1);
+    expect(result.itemCount).toBe(3);
+    // Person rows never match a stream-provider filter, so no person lookup runs.
+    expect(getPersonDetails).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty page but a non-zero itemCount when nothing matches', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chain([list]))
+      .mockReturnValueOnce(chain(itemRows));
+
+    const result = await getListDetailsWithResources(UUID, 1, [999], 'SE');
+
+    expect(result.allItems).toEqual([]);
+    expect(result.totalItems).toBe(0);
+    expect(result.totalPages).toBe(0);
+    expect(result.itemCount).toBe(3);
+  });
+
+  it('rejects an unknown watch region before querying', async () => {
+    await expect(getListDetailsWithResources(UUID, 1, [8], 'XX')).rejects.toThrow();
+    expect(db.select).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/lists.ts
+++ b/src/lib/lists.ts
@@ -15,6 +15,7 @@ import { CACHE_TAGS } from '@/lib/cache-tags';
 import { db } from '@/lib/db';
 import { buildProxyImageUrls } from '@/lib/imgproxy-url';
 import { moveIdToIndex } from '@/lib/list-order';
+import { paginate } from '@/lib/paginate';
 import {
   listItemOrderingScope,
   listOrderingScope,
@@ -33,7 +34,12 @@ import {
   removeListItemSchema,
   SystemListType,
   updateListSchema,
+  WatchProviderFilter,
 } from '@/lib/validations';
+import {
+  filterRowsByWatchProviders,
+  parseWatchProviderFilter,
+} from '@/lib/watch-provider-availability';
 
 import { ITEMS_PER_PAGE, LISTS_PER_PAGE } from './config';
 
@@ -224,9 +230,25 @@ export async function getUserListsPaginated(page: number = 1) {
  * @param itemsPerPage - The number of items per page.
  * @returns An object containing the list details, paginated items, and pagination metadata.
  */
-async function getListDetailsPaginated(listId: string, page: number = 1) {
+async function getListDetailsPaginated(
+  listId: string,
+  page: number = 1,
+  providerFilter: WatchProviderFilter | null = null,
+) {
   const user = await requireUser();
 
+  validateListDetailsParams(listId, page);
+
+  const list = await fetchOwnedCustomListRow(listId, user.id);
+
+  if (providerFilter) {
+    return await queryProviderFilteredListPage(list, page, providerFilter);
+  }
+
+  return await queryUnfilteredListPage(list, page);
+}
+
+function validateListDetailsParams(listId: string, page: number) {
   if (!listIdSchema.safeParse(listId).success) {
     redirect('/lists');
   }
@@ -234,30 +256,32 @@ async function getListDetailsPaginated(listId: string, page: number = 1) {
   if (!pageSchema.safeParse(page).success) {
     redirect(`/lists/${listId}`);
   }
+}
 
+/** @throws {Error} 'List not found' unless the list is an owned custom list. */
+async function fetchOwnedCustomListRow(listId: string, userId: string) {
   const listResult = await db
     .select()
     .from(lists)
-    .where(and(eq(lists.id, listId), ownedCustomListsFilter(user.id)));
+    .where(and(eq(lists.id, listId), ownedCustomListsFilter(userId)));
 
   if (listResult.length === 0) {
     throw new Error('List not found');
   }
 
-  const list = listResult[0];
+  return listResult[0];
+}
 
+async function queryUnfilteredListPage(list: typeof lists.$inferSelect, page: number) {
   const totalCountResult = await db
     .select({ count: count() })
     .from(listItems)
-    .where(eq(listItems.listId, listId));
+    .where(eq(listItems.listId, list.id));
 
   // Safely coerce count to number, handling BigInt/string/null cases
   const totalItems = Number(totalCountResult[0]?.count) || 0;
   const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
-
-  // Parse and clamp page to valid range
-  const parsedPage = parseInt(String(page), 10) || 1;
-  const currentPage = Math.max(1, Math.min(parsedPage, totalPages || 1));
+  const currentPage = Math.max(1, Math.min(page, totalPages || 1));
 
   if (totalItems === 0) {
     return {
@@ -276,7 +300,7 @@ async function getListDetailsPaginated(listId: string, page: number = 1) {
   const items = await db
     .select()
     .from(listItems)
-    .where(eq(listItems.listId, listId))
+    .where(eq(listItems.listId, list.id))
     .orderBy(...itemManualOrder())
     .limit(ITEMS_PER_PAGE)
     .offset(offset);
@@ -293,15 +317,55 @@ async function getListDetailsPaginated(listId: string, page: number = 1) {
 }
 
 /**
+ * Stream-provider-filtered page of a custom list: availability lives in TMDB
+ * rather than the database, so every item is loaded, filtered by
+ * streamability (person items never match), and paginated in memory.
+ * `itemCount` stays the unfiltered total so headers and delete confirmations
+ * keep describing the whole list, while the pagination metadata reflects the
+ * filtered set.
+ */
+async function queryProviderFilteredListPage(
+  list: typeof lists.$inferSelect,
+  page: number,
+  providerFilter: WatchProviderFilter,
+) {
+  const allRows = await db
+    .select()
+    .from(listItems)
+    .where(eq(listItems.listId, list.id))
+    .orderBy(...itemManualOrder());
+
+  const matching = await filterRowsByWatchProviders(allRows, providerFilter);
+  const { pageItems, ...pagination } = paginate(matching, page, ITEMS_PER_PAGE);
+
+  return {
+    ...list,
+    items: pageItems,
+    itemCount: allRows.length,
+    ...pagination,
+  };
+}
+
+/**
  * Fetches list details with all resource details populated.
  * Helper function to avoid code duplication.
+ *
+ * @param watchProviders - When non-empty, only items streamable on any of
+ * these TMDB provider ids (in `watchRegion`) are returned.
+ * @param watchRegion - The region used for the provider availability check.
  */
-export async function getListDetailsWithResources(listId: string, page: number = 1) {
+export async function getListDetailsWithResources(
+  listId: string,
+  page: number = 1,
+  watchProviders?: number[],
+  watchRegion?: string,
+) {
   const { getMovieDetails } = await import('@/lib/movies');
   const { getTvShowDetails } = await import('@/lib/tv-shows');
   const { getPersonDetails } = await import('@/lib/persons');
 
-  const paginatedList = await getListDetailsPaginated(listId, page);
+  const providerFilter = parseWatchProviderFilter(watchProviders, watchRegion);
+  const paginatedList = await getListDetailsPaginated(listId, page, providerFilter);
 
   // Fetch details for paginated items only
   const movieItems = paginatedList.items?.filter((item) => item.resourceType === 'movie') || [];

--- a/src/lib/paginate.test.ts
+++ b/src/lib/paginate.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { paginate } from './paginate';
+
+describe('paginate', () => {
+  const items = ['a', 'b', 'c', 'd', 'e'];
+
+  it('returns the requested page slice with metadata', () => {
+    expect(paginate(items, 2, 2)).toEqual({
+      pageItems: ['c', 'd'],
+      totalItems: 5,
+      totalPages: 3,
+      currentPage: 2,
+      itemsPerPage: 2,
+    });
+  });
+
+  it('clamps past-the-end pages to the last page', () => {
+    const result = paginate(items, 99, 2);
+
+    expect(result.pageItems).toEqual(['e']);
+    expect(result.currentPage).toBe(3);
+  });
+
+  it('clamps pages below 1 up to the first page', () => {
+    const result = paginate(items, 0, 2);
+
+    expect(result.pageItems).toEqual(['a', 'b']);
+    expect(result.currentPage).toBe(1);
+  });
+
+  it('returns an empty first page for an empty set', () => {
+    expect(paginate([], 3, 2)).toEqual({
+      pageItems: [],
+      totalItems: 0,
+      totalPages: 0,
+      currentPage: 1,
+      itemsPerPage: 2,
+    });
+  });
+});

--- a/src/lib/paginate.ts
+++ b/src/lib/paginate.ts
@@ -1,0 +1,20 @@
+/**
+ * Slices a fully materialized item set down to one page. Used by the list
+ * queries when the stream-provider filter forces in-memory pagination;
+ * `currentPage` is clamped to the last page so an out-of-range request still
+ * returns content.
+ */
+export function paginate<T>(items: T[], page: number, itemsPerPage: number) {
+  const totalItems = items.length;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const currentPage = Math.max(1, Math.min(page, totalPages || 1));
+  const offset = (currentPage - 1) * itemsPerPage;
+
+  return {
+    pageItems: items.slice(offset, offset + itemsPerPage),
+    totalItems,
+    totalPages,
+    currentPage,
+    itemsPerPage,
+  };
+}

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -22,7 +22,12 @@ function systemListKeys<Root extends string>(root: Root) {
   return {
     all,
     lists,
-    list: (mediaType: 'movie' | 'tv', page: number) => [...lists(), mediaType, page] as const,
+    list: (
+      mediaType: 'movie' | 'tv',
+      page: number,
+      watchProviders?: number[],
+      watchRegion?: string,
+    ) => [...lists(), mediaType, page, watchProviders, watchRegion] as const,
     counts,
     count: (mediaType: 'movie' | 'tv') => [...counts(), mediaType] as const,
     status: (resourceId: number, resourceType: string) =>
@@ -48,7 +53,8 @@ export const queryKeys = {
   lists: {
     all: ['lists'] as const,
     details: () => [...queryKeys.lists.all, 'detail'] as const,
-    detail: (listId: string, page: number) => [...queryKeys.lists.details(), listId, page] as const,
+    detail: (listId: string, page: number, watchProviders?: number[], watchRegion?: string) =>
+      [...queryKeys.lists.details(), listId, page, watchProviders, watchRegion] as const,
     withStatus: (mediaId: number, mediaType: string) =>
       [...queryKeys.lists.all, 'withStatus', mediaId, mediaType] as const,
   },

--- a/src/lib/system-list-queries.test.ts
+++ b/src/lib/system-list-queries.test.ts
@@ -264,4 +264,14 @@ describe('getSystemListWithResourceDetailsPaginated with a provider filter', () 
     ).rejects.toThrow();
     expect(db.select).not.toHaveBeenCalled();
   });
+
+  it('propagates availability-lookup failures instead of returning an empty page', async () => {
+    vi.mocked(db.select).mockReturnValue(chain(rows));
+    vi.mocked(getMovieWatchProviders).mockRejectedValue(new Error('TMDB down'));
+
+    // An empty page here would render as "no titles match your providers".
+    await expect(
+      getSystemListWithResourceDetailsPaginated('watchlist', 'movie', 1, [8], 'SE'),
+    ).rejects.toThrow('TMDB down');
+  });
 });

--- a/src/lib/system-list-queries.test.ts
+++ b/src/lib/system-list-queries.test.ts
@@ -3,13 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/lib/db', () => ({ db: { select: vi.fn() } }));
 vi.mock('@/lib/auth-server', () => ({ getUser: vi.fn() }));
 vi.mock('next/cache', () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }));
-vi.mock('@/lib/movies', () => ({ getMovieDetails: vi.fn() }));
-vi.mock('@/lib/tv-shows', () => ({ getTvShowDetails: vi.fn() }));
+vi.mock('@/lib/movies', () => ({ getMovieDetails: vi.fn(), getMovieWatchProviders: vi.fn() }));
+vi.mock('@/lib/tv-shows', () => ({
+  getTvShowDetails: vi.fn(),
+  getTvShowWatchProviders: vi.fn(),
+}));
 vi.mock('@/lib/imgproxy-url', () => ({ buildProxyImageUrls: vi.fn(() => ({ src: 'proxied' })) }));
 
 import { getUser } from '@/lib/auth-server';
 import { db } from '@/lib/db';
-import { getMovieDetails } from '@/lib/movies';
+import { getMovieDetails, getMovieWatchProviders } from '@/lib/movies';
 import { getTvShowDetails } from '@/lib/tv-shows';
 import { chain } from '@/test/db-chain';
 
@@ -179,5 +182,86 @@ describe('getSystemListWithResourceDetailsPaginated', () => {
 
     expect(result.items).toEqual([]);
     expect(result.totalItems).toBe(0);
+  });
+});
+
+describe('getSystemListWithResourceDetailsPaginated with a provider filter', () => {
+  const rows = [
+    { id: 'item-1', resourceId: 1, resourceType: 'movie', createdAt: new Date(0) },
+    { id: 'item-2', resourceId: 2, resourceType: 'movie', createdAt: new Date(1) },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(getMovieDetails).mockImplementation(
+      async (movieId: number) => ({ id: movieId, poster_path: null }) as never,
+    );
+    // Movie 1 streams on provider 8 in SE; movie 2 streams nowhere.
+    vi.mocked(getMovieWatchProviders).mockImplementation(async (movieId: number) => ({
+      results:
+        movieId === 1
+          ? {
+              SE: {
+                link: 'https://tmdb',
+                flatrate: [
+                  { provider_id: 8, provider_name: 'Netflix', logo_path: '/n.png', display_priority: 1 },
+                ],
+              },
+            }
+          : {},
+    }));
+  });
+
+  it('returns only items streamable on the selected providers', async () => {
+    vi.mocked(db.select).mockReturnValue(chain(rows));
+
+    const result = await getSystemListWithResourceDetailsPaginated(
+      'watchlist',
+      'movie',
+      1,
+      [8],
+      'SE',
+    );
+
+    expect(result.items.map((item) => item.id)).toEqual([1]);
+    expect(result.totalItems).toBe(1);
+    expect(result.totalPages).toBe(1);
+    // The filtered path paginates in memory: one row query, no count query.
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty page when nothing matches the filter', async () => {
+    vi.mocked(db.select).mockReturnValue(chain(rows));
+
+    const result = await getSystemListWithResourceDetailsPaginated(
+      'watched',
+      'movie',
+      1,
+      [999],
+      'SE',
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.totalItems).toBe(0);
+    expect(result.totalPages).toBe(0);
+    expect(getMovieDetails).not.toHaveBeenCalled();
+  });
+
+  it('skips availability lookups when the filter is empty', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chain([{ count: 2 }]))
+      .mockReturnValueOnce(chain(rows));
+
+    const result = await getSystemListWithResourceDetailsPaginated('watchlist', 'movie', 1, []);
+
+    expect(result.totalItems).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(getMovieWatchProviders).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown watch region before querying', async () => {
+    await expect(
+      getSystemListWithResourceDetailsPaginated('watchlist', 'movie', 1, [8], 'XX'),
+    ).rejects.toThrow();
+    expect(db.select).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/system-list-queries.ts
+++ b/src/lib/system-list-queries.ts
@@ -9,13 +9,19 @@ import { SYSTEM_LIST_CACHE_TAGS } from '@/lib/cache-tags';
 import { db } from '@/lib/db';
 import { buildProxyImageUrls } from '@/lib/imgproxy-url';
 import { getMovieDetails } from '@/lib/movies';
+import { paginate } from '@/lib/paginate';
 import {
   pageSchema,
   resourceIdSchema,
   resourceTypeSchema,
   SystemListType,
   systemListTypeSchema,
+  WatchProviderFilter,
 } from '@/lib/validations';
+import {
+  filterRowsByWatchProviders,
+  parseWatchProviderFilter,
+} from '@/lib/watch-provider-availability';
 import { MovieDetails } from '@/types/movie';
 import type { ProxyImageUrls } from '@/types/proxy-image';
 import { TvDetails } from '@/types/tv-show';
@@ -125,17 +131,23 @@ export async function getSystemListMemberships(resourceId: number, resourceType:
  * @param listType - The system list to read ('watchlist' or 'watched').
  * @param resourceType - The type of resource to include ('movie' or 'tv').
  * @param page - The page number (1-based).
+ * @param watchProviders - When non-empty, only items streamable on any of
+ * these TMDB provider ids (in `watchRegion`) are returned.
+ * @param watchRegion - The region used for the provider availability check.
  * @returns An object containing the paginated items and pagination metadata.
  */
 export async function getSystemListWithResourceDetailsPaginated(
   listType: SystemListType,
   resourceType: 'movie' | 'tv',
   page: number = 1,
+  watchProviders?: number[],
+  watchRegion?: string,
 ) {
   if (!resourceTypeSchema.safeParse(resourceType).success || !pageSchema.safeParse(page).success) {
     throw new Error('Invalid resource type or page number');
   }
   systemListTypeSchema.parse(listType);
+  const providerFilter = parseWatchProviderFilter(watchProviders, watchRegion);
 
   const user = await getUser();
   if (!user) {
@@ -143,7 +155,7 @@ export async function getSystemListWithResourceDetailsPaginated(
   }
 
   try {
-    return await queryPageWithResourceDetails(user.id, listType, resourceType, page);
+    return await queryPageWithResourceDetails(user.id, listType, resourceType, page, providerFilter);
   } catch (error) {
     console.error(`Error fetching paginated ${listType}:`, error);
     return emptyPage(page);
@@ -155,11 +167,16 @@ async function queryPageWithResourceDetails(
   listType: SystemListType,
   resourceType: 'movie' | 'tv',
   page: number,
+  providerFilter: WatchProviderFilter | null,
 ) {
   const filter = and(
     systemListItemsFilter(userId, listType),
     eq(listItems.resourceType, resourceType),
   );
+
+  if (providerFilter) {
+    return await queryProviderFilteredPage(filter, resourceType, page, providerFilter);
+  }
 
   const totalCountResult = await db
     .select({ count: count() })
@@ -172,17 +189,7 @@ async function queryPageWithResourceDetails(
     return emptyPage(page);
   }
 
-  const rows = await db
-    .select({
-      id: listItems.id,
-      resourceId: listItems.resourceId,
-      resourceType: listItems.resourceType,
-      createdAt: listItems.createdAt,
-    })
-    .from(listItems)
-    .innerJoin(lists, eq(listItems.listId, lists.id))
-    .where(filter)
-    .orderBy(asc(listItems.position), desc(listItems.createdAt))
+  const rows = await selectSystemListRows(filter)
     .limit(ITEMS_PER_PAGE)
     .offset((page - 1) * ITEMS_PER_PAGE);
 
@@ -192,6 +199,46 @@ async function queryPageWithResourceDetails(
     totalPages: Math.ceil(totalItems / ITEMS_PER_PAGE),
     currentPage: page,
     itemsPerPage: ITEMS_PER_PAGE,
+  };
+}
+
+function selectSystemListRows(filter: SQL | undefined) {
+  return db
+    .select({
+      id: listItems.id,
+      resourceId: listItems.resourceId,
+      resourceType: listItems.resourceType,
+      createdAt: listItems.createdAt,
+    })
+    .from(listItems)
+    .innerJoin(lists, eq(listItems.listId, lists.id))
+    .where(filter)
+    .orderBy(asc(listItems.position), desc(listItems.createdAt));
+}
+
+/**
+ * Stream-provider-filtered page: availability lives in TMDB rather than the
+ * database, so every row is loaded, filtered by streamability, and paginated
+ * in memory. Pagination metadata reflects the filtered set.
+ */
+async function queryProviderFilteredPage(
+  filter: SQL | undefined,
+  resourceType: 'movie' | 'tv',
+  page: number,
+  providerFilter: WatchProviderFilter,
+) {
+  const rows = await selectSystemListRows(filter);
+  const matching = await filterRowsByWatchProviders(rows, providerFilter);
+
+  if (matching.length === 0) {
+    return emptyPage(page);
+  }
+
+  const { pageItems, ...pagination } = paginate(matching, page, ITEMS_PER_PAGE);
+
+  return {
+    items: await hydrateResourceDetails(pageItems, resourceType),
+    ...pagination,
   };
 }
 

--- a/src/lib/system-list-queries.ts
+++ b/src/lib/system-list-queries.ts
@@ -158,6 +158,11 @@ export async function getSystemListWithResourceDetailsPaginated(
     return await queryPageWithResourceDetails(user.id, listType, resourceType, page, providerFilter);
   } catch (error) {
     console.error(`Error fetching paginated ${listType}:`, error);
+    // With a provider filter active, an empty page reads as "nothing matches
+    // your providers" — a lie during an outage. Let the client show an error.
+    if (providerFilter) {
+      throw error;
+    }
     return emptyPage(page);
   }
 }

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 
 import { EMOJI_OPTIONS } from '@/lib/config';
+import { isValidRegionCode } from '@/lib/regions';
 
 /**
  * Validates that a movieId is a valid string that can be converted to a positive integer.
@@ -123,3 +124,14 @@ export const mediaTypeSchema = z.enum(['movie', 'tv', 'person']);
 
 export const listIdSchema = z.uuid('Invalid list ID');
 export const pageSchema = z.number().int().min(1);
+
+/**
+ * Schema for the optional stream-provider filter on list pages: at least one
+ * TMDB provider id plus the region whose availability should be checked.
+ */
+export const watchProviderFilterSchema = z.object({
+  providerIds: z.array(z.number().int().min(1)).min(1),
+  region: z.string().refine(isValidRegionCode, 'Invalid region code'),
+});
+
+export type WatchProviderFilter = z.infer<typeof watchProviderFilterSchema>;

--- a/src/lib/watch-provider-availability.test.ts
+++ b/src/lib/watch-provider-availability.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/movies', () => ({ getMovieWatchProviders: vi.fn() }));
+vi.mock('@/lib/tv-shows', () => ({ getTvShowWatchProviders: vi.fn() }));
+
+import { getMovieWatchProviders } from '@/lib/movies';
+import { getTvShowWatchProviders } from '@/lib/tv-shows';
+import type { WatchProvider } from '@/types/watch-provider';
+
+import {
+  filterRowsByWatchProviders,
+  matchesWatchProviders,
+  parseWatchProviderFilter,
+} from './watch-provider-availability';
+
+function offer(id: number): WatchProvider {
+  return { provider_id: id, provider_name: `Provider ${id}`, logo_path: '/logo.png', display_priority: 1 };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('parseWatchProviderFilter', () => {
+  it('returns null when no providers are requested', () => {
+    expect(parseWatchProviderFilter(undefined, 'SE')).toBeNull();
+    expect(parseWatchProviderFilter([], 'SE')).toBeNull();
+  });
+
+  it('validates providers and keeps the given region', () => {
+    expect(parseWatchProviderFilter([8, 337], 'US')).toEqual({
+      providerIds: [8, 337],
+      region: 'US',
+    });
+  });
+
+  it('falls back to the default region when none is given', () => {
+    expect(parseWatchProviderFilter([8])).toEqual({ providerIds: [8], region: 'SE' });
+  });
+
+  it('rejects unknown regions', () => {
+    expect(() => parseWatchProviderFilter([8], 'XX')).toThrow();
+  });
+
+  it('rejects malformed provider ids', () => {
+    expect(() => parseWatchProviderFilter([0], 'SE')).toThrow();
+    expect(() => parseWatchProviderFilter([1.5], 'SE')).toThrow();
+  });
+});
+
+describe('matchesWatchProviders', () => {
+  const filter = { providerIds: [8, 337], region: 'SE' };
+
+  it('matches a movie streamable via flatrate on a selected provider', async () => {
+    vi.mocked(getMovieWatchProviders).mockResolvedValue({
+      results: { SE: { link: 'https://tmdb', flatrate: [offer(8)] } },
+    });
+
+    await expect(
+      matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
+    ).resolves.toBe(true);
+    expect(getMovieWatchProviders).toHaveBeenCalledWith(1);
+  });
+
+  it('matches a title available for free on a selected provider', async () => {
+    vi.mocked(getMovieWatchProviders).mockResolvedValue({
+      results: { SE: { link: 'https://tmdb', free: [offer(337)] } },
+    });
+
+    await expect(
+      matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
+    ).resolves.toBe(true);
+  });
+
+  it('does not match rent- or buy-only availability', async () => {
+    vi.mocked(getMovieWatchProviders).mockResolvedValue({
+      results: { SE: { link: 'https://tmdb', rent: [offer(8)], buy: [offer(337)] } },
+    });
+
+    await expect(
+      matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
+    ).resolves.toBe(false);
+  });
+
+  it('does not match availability in other regions only', async () => {
+    vi.mocked(getMovieWatchProviders).mockResolvedValue({
+      results: { US: { link: 'https://tmdb', flatrate: [offer(8)] } },
+    });
+
+    await expect(
+      matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
+    ).resolves.toBe(false);
+  });
+
+  it('does not match providers outside the selected set', async () => {
+    vi.mocked(getMovieWatchProviders).mockResolvedValue({
+      results: { SE: { link: 'https://tmdb', flatrate: [offer(9)] } },
+    });
+
+    await expect(
+      matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
+    ).resolves.toBe(false);
+  });
+
+  it('checks TV shows through the TV provider endpoint', async () => {
+    vi.mocked(getTvShowWatchProviders).mockResolvedValue({
+      results: { SE: { link: 'https://tmdb', flatrate: [offer(337)] } },
+    });
+
+    await expect(matchesWatchProviders({ resourceType: 'tv', resourceId: 42 }, filter)).resolves.toBe(
+      true,
+    );
+    expect(getTvShowWatchProviders).toHaveBeenCalledWith(42);
+    expect(getMovieWatchProviders).not.toHaveBeenCalled();
+  });
+
+  it('never matches person rows and skips the lookup', async () => {
+    await expect(
+      matchesWatchProviders({ resourceType: 'person', resourceId: 7 }, filter),
+    ).resolves.toBe(false);
+    expect(getMovieWatchProviders).not.toHaveBeenCalled();
+    expect(getTvShowWatchProviders).not.toHaveBeenCalled();
+  });
+
+  it('treats a failed provider lookup as not matching', async () => {
+    vi.mocked(getMovieWatchProviders).mockRejectedValue(new Error('TMDB down'));
+
+    await expect(
+      matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
+    ).resolves.toBe(false);
+  });
+});
+
+describe('filterRowsByWatchProviders', () => {
+  it('keeps only streamable rows, preserving order', async () => {
+    vi.mocked(getMovieWatchProviders).mockImplementation(async (movieId: number) => ({
+      results:
+        movieId % 2 === 1 ? { SE: { link: 'https://tmdb', flatrate: [offer(8)] } } : {},
+    }));
+
+    const rows = [
+      { resourceId: 1, resourceType: 'movie' },
+      { resourceId: 2, resourceType: 'movie' },
+      { resourceId: 3, resourceType: 'movie' },
+      { resourceId: 4, resourceType: 'person' },
+    ];
+
+    const result = await filterRowsByWatchProviders(rows, { providerIds: [8], region: 'SE' });
+
+    expect(result).toEqual([
+      { resourceId: 1, resourceType: 'movie' },
+      { resourceId: 3, resourceType: 'movie' },
+    ]);
+  });
+});

--- a/src/lib/watch-provider-availability.test.ts
+++ b/src/lib/watch-provider-availability.test.ts
@@ -122,12 +122,12 @@ describe('matchesWatchProviders', () => {
     expect(getTvShowWatchProviders).not.toHaveBeenCalled();
   });
 
-  it('treats a failed provider lookup as not matching', async () => {
+  it('propagates a failed provider lookup instead of reporting unavailable', async () => {
     vi.mocked(getMovieWatchProviders).mockRejectedValue(new Error('TMDB down'));
 
     await expect(
       matchesWatchProviders({ resourceType: 'movie', resourceId: 1 }, filter),
-    ).resolves.toBe(false);
+    ).rejects.toThrow('TMDB down');
   });
 });
 
@@ -151,5 +151,29 @@ describe('filterRowsByWatchProviders', () => {
       { resourceId: 1, resourceType: 'movie' },
       { resourceId: 3, resourceType: 'movie' },
     ]);
+  });
+
+  it('bounds concurrent lookups while still filtering every row', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    vi.mocked(getMovieWatchProviders).mockImplementation(async (movieId: number) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight--;
+      return {
+        results: movieId % 2 === 1 ? { SE: { link: 'https://tmdb', flatrate: [offer(8)] } } : {},
+      };
+    });
+
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      resourceId: i + 1,
+      resourceType: 'movie',
+    }));
+
+    const result = await filterRowsByWatchProviders(rows, { providerIds: [8], region: 'SE' });
+
+    expect(result).toHaveLength(13);
+    expect(maxInFlight).toBeLessThanOrEqual(10);
   });
 });

--- a/src/lib/watch-provider-availability.ts
+++ b/src/lib/watch-provider-availability.ts
@@ -47,30 +47,44 @@ async function fetchRegionProviders(resourceType: 'movie' | 'tv', resourceId: nu
 
 /**
  * Whether a list item can be streamed on any of the filter's providers in the
- * filter's region. Person rows and failed provider lookups never match.
+ * filter's region. Person rows never match. A failed provider lookup throws
+ * (after tmdbFetch's own retries) instead of silently reporting the title as
+ * unavailable, so an outage can't render a populated list as "no matches".
  */
 export async function matchesWatchProviders(row: ListItemResource, filter: WatchProviderFilter) {
   if (row.resourceType !== 'movie' && row.resourceType !== 'tv') {
     return false;
   }
 
-  try {
-    const regionProviders = await fetchRegionProviders(row.resourceType, row.resourceId, filter.region);
-    return streamableProviderIds(regionProviders).some((id) => filter.providerIds.includes(id));
-  } catch {
-    return false;
-  }
+  const regionProviders = await fetchRegionProviders(
+    row.resourceType,
+    row.resourceId,
+    filter.region,
+  );
+  return streamableProviderIds(regionProviders).some((id) => filter.providerIds.includes(id));
 }
+
+// Caps concurrent TMDB availability lookups so a large list with a cold cache
+// doesn't fire hundreds of requests at once (tmdbFetch retries but has no
+// concurrency limit of its own).
+const MAX_CONCURRENT_LOOKUPS = 10;
 
 /**
  * Keeps the rows streamable on any of the filter's providers, preserving the
- * input order. Availability lookups run in parallel and are cached for days,
- * so filtering a whole list stays cheap.
+ * input order. Lookups run in bounded batches and are cached for days, so
+ * filtering a whole list stays cheap on a warm cache.
  */
 export async function filterRowsByWatchProviders<T extends ListItemResource>(
   rows: T[],
   filter: WatchProviderFilter,
 ): Promise<T[]> {
-  const matches = await Promise.all(rows.map((row) => matchesWatchProviders(row, filter)));
+  // ponytail: batch barrier, not a work pool — swap in a pool if list sizes
+  // make the slowest-in-batch stalls matter.
+  const matches: boolean[] = [];
+  for (let i = 0; i < rows.length; i += MAX_CONCURRENT_LOOKUPS) {
+    const batch = rows.slice(i, i + MAX_CONCURRENT_LOOKUPS);
+    matches.push(...(await Promise.all(batch.map((row) => matchesWatchProviders(row, filter)))));
+  }
+
   return rows.filter((_, index) => matches[index]);
 }

--- a/src/lib/watch-provider-availability.ts
+++ b/src/lib/watch-provider-availability.ts
@@ -1,0 +1,76 @@
+import 'server-only';
+
+import { getMovieWatchProviders } from '@/lib/movies';
+import { DEFAULT_REGION, RegionCode } from '@/lib/regions';
+import { getTvShowWatchProviders } from '@/lib/tv-shows';
+import { WatchProviderFilter, watchProviderFilterSchema } from '@/lib/validations';
+import type { RegionWatchProviders } from '@/types/watch-provider';
+
+type ListItemResource = {
+  resourceId: number;
+  resourceType: string;
+};
+
+/**
+ * Normalizes the raw stream-provider filter input of a list query. Returns
+ * `null` when no providers were requested (the filter is inactive); otherwise
+ * validates the ids and region.
+ *
+ * @throws {ZodError} When providers are requested with malformed ids or an
+ * unknown region.
+ */
+export function parseWatchProviderFilter(
+  providerIds?: number[],
+  region?: string,
+): WatchProviderFilter | null {
+  if (!providerIds || providerIds.length === 0) {
+    return null;
+  }
+
+  return watchProviderFilterSchema.parse({ providerIds, region: region ?? DEFAULT_REGION });
+}
+
+/** Provider ids a title can be streamed on (flatrate or free) in a region. */
+function streamableProviderIds(regionProviders: RegionWatchProviders | undefined) {
+  const offers = [...(regionProviders?.flatrate ?? []), ...(regionProviders?.free ?? [])];
+  return offers.map((provider) => provider.provider_id);
+}
+
+async function fetchRegionProviders(resourceType: 'movie' | 'tv', resourceId: number, region: string) {
+  const providers =
+    resourceType === 'movie'
+      ? await getMovieWatchProviders(resourceId)
+      : await getTvShowWatchProviders(resourceId);
+
+  return providers.results?.[region as RegionCode];
+}
+
+/**
+ * Whether a list item can be streamed on any of the filter's providers in the
+ * filter's region. Person rows and failed provider lookups never match.
+ */
+export async function matchesWatchProviders(row: ListItemResource, filter: WatchProviderFilter) {
+  if (row.resourceType !== 'movie' && row.resourceType !== 'tv') {
+    return false;
+  }
+
+  try {
+    const regionProviders = await fetchRegionProviders(row.resourceType, row.resourceId, filter.region);
+    return streamableProviderIds(regionProviders).some((id) => filter.providerIds.includes(id));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Keeps the rows streamable on any of the filter's providers, preserving the
+ * input order. Availability lookups run in parallel and are cached for days,
+ * so filtering a whole list stays cheap.
+ */
+export async function filterRowsByWatchProviders<T extends ListItemResource>(
+  rows: T[],
+  filter: WatchProviderFilter,
+): Promise<T[]> {
+  const matches = await Promise.all(rows.map((row) => matchesWatchProviders(row, filter)));
+  return rows.filter((_, index) => matches[index]);
+}

--- a/src/lib/watch-provider-filter-context.test.ts
+++ b/src/lib/watch-provider-filter-context.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/user-actions', () => ({
+  getUserRegion: vi.fn(),
+  getUserWatchProviders: vi.fn(),
+  getWatchProviders: vi.fn(),
+}));
+
+import { getUserRegion, getUserWatchProviders, getWatchProviders } from '@/lib/user-actions';
+
+import { getWatchProviderFilterContext } from './watch-provider-filter-context';
+
+const netflix = { provider_id: 8, provider_name: 'Netflix', logo_path: '/n.png', display_priority: 1 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getUserRegion).mockResolvedValue('SE');
+  vi.mocked(getUserWatchProviders).mockResolvedValue([8]);
+  vi.mocked(getWatchProviders).mockResolvedValue([netflix]);
+});
+
+describe('getWatchProviderFilterContext', () => {
+  it('uses the URL region without reading the stored region', async () => {
+    const result = await getWatchProviderFilterContext('US');
+
+    expect(result).toEqual({ userRegion: 'US', availableWatchProviders: [netflix] });
+    expect(getUserRegion).not.toHaveBeenCalled();
+    expect(getWatchProviders).toHaveBeenCalledWith('US', [8]);
+  });
+
+  it('falls back to the stored region when the URL pins none', async () => {
+    const result = await getWatchProviderFilterContext(null);
+
+    expect(result.userRegion).toBe('SE');
+    expect(getWatchProviders).toHaveBeenCalledWith('SE', [8]);
+  });
+});

--- a/src/lib/watch-provider-filter-context.ts
+++ b/src/lib/watch-provider-filter-context.ts
@@ -1,0 +1,20 @@
+import 'server-only';
+
+import { getUserRegion, getUserWatchProviders, getWatchProviders } from '@/lib/user-actions';
+
+/**
+ * Resolves what a list page needs to render the stream-provider filter: the
+ * effective region (URL override, else the user's stored region) and the
+ * providers available to pick from in that region. The independent lookups
+ * run in parallel.
+ */
+export async function getWatchProviderFilterContext(watchRegionParam: string | null) {
+  const [userRegion, userWatchProviders] = await Promise.all([
+    watchRegionParam ?? getUserRegion(),
+    getUserWatchProviders(),
+  ]);
+
+  const availableWatchProviders = await getWatchProviders(userRegion, userWatchProviders);
+
+  return { userRegion, availableWatchProviders };
+}

--- a/src/lib/watch-provider-search-params.test.ts
+++ b/src/lib/watch-provider-search-params.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_REGION } from './regions';
 import {
+  activeWatchProviderFilter,
   getWatchProvidersString,
   loadWatchProviderSearchParams,
   parseAsPipeSeparatedArrayOfIntegers,
 } from './watch-provider-search-params';
 
 describe('loadWatchProviderSearchParams', () => {
-  it('defaults to empty providers and the default region', () => {
+  it('defaults to empty providers and no pinned region', () => {
+    // watch_region intentionally has no default: callers fall back to the
+    // user's stored region when the URL does not pin one.
     expect(loadWatchProviderSearchParams({})).toEqual({
       with_watch_providers: [],
-      watch_region: DEFAULT_REGION,
+      watch_region: null,
     });
   });
 
@@ -21,6 +23,22 @@ describe('loadWatchProviderSearchParams', () => {
     ).toEqual({
       with_watch_providers: [8, 337],
       watch_region: 'US',
+    });
+  });
+});
+
+describe('activeWatchProviderFilter', () => {
+  it('is inactive (both members undefined) while no providers are selected', () => {
+    expect(activeWatchProviderFilter([], 'SE')).toEqual({
+      activeProviders: undefined,
+      activeRegion: undefined,
+    });
+  });
+
+  it('returns the providers and region once providers are selected', () => {
+    expect(activeWatchProviderFilter([8, 337], 'US')).toEqual({
+      activeProviders: [8, 337],
+      activeRegion: 'US',
     });
   });
 });

--- a/src/lib/watch-provider-search-params.ts
+++ b/src/lib/watch-provider-search-params.ts
@@ -6,12 +6,25 @@ import {
   parseAsString,
 } from 'nuqs/server';
 
-import { DEFAULT_REGION } from './regions';
-
+// `watch_region` has no default on purpose: callers fall back to the user's
+// stored region when the URL does not pin one.
 export const loadWatchProviderSearchParams = createLoader({
   with_watch_providers: parseAsArrayOf(parseAsInteger).withDefault([]),
-  watch_region: parseAsString.withDefault(DEFAULT_REGION),
+  watch_region: parseAsString,
 });
+
+/**
+ * Normalizes the active stream-provider filter from parsed search params:
+ * both members are `undefined` while no providers are selected, so query keys
+ * and server calls stay identical between server shells and client content.
+ */
+export function activeWatchProviderFilter(withWatchProviders: number[], region: string) {
+  if (withWatchProviders.length === 0) {
+    return { activeProviders: undefined, activeRegion: undefined };
+  }
+
+  return { activeProviders: withWatchProviders, activeRegion: region };
+}
 
 export function getWatchProvidersString(urlProviders: number[], userProviders: number[]) {
   if (urlProviders.length > 0) {


### PR DESCRIPTION
## What

Adds the watch-provider filter (same popover as on /discover) to the watchlist, watched, and custom list pages. Selecting providers narrows the list to titles that are streamable (flatrate or free) on any of the selected services in the user's region.

## How

- **Availability check** (`watch-provider-availability.ts`): per-title `watch/providers` lookups via the existing day-cached TMDB fetchers; a row matches when its flatrate/free provider ids intersect the selected set. Person rows and failed lookups never match.
- **Filtered pagination**: availability lives in TMDB, not the DB, so when the filter is active the queries load all rows, filter, and paginate in memory (`paginate.ts`). Pagination metadata reflects the filtered set; a custom list's `itemCount` stays the unfiltered total so the header and delete confirmation keep describing the whole list.
- **URL state**: `with_watch_providers` + `watch_region` via nuqs, exactly like discover. The filter is only active when the URL sets providers — the user's default providers from settings never implicitly hide list items.
- **Prefetch parity**: server shells and client content normalize the filter through the same helper (`activeWatchProviderFilter`) so hydrated query keys match.
- Reordering is disabled while filtered: the visible rows are a non-contiguous slice, so page offsets no longer map to positions in the full manual order.
- Filtered-empty states get their own copy instead of pretending the list is empty.

## Tests

- `watch-provider-availability`, `paginate`, `watch-provider-filter-context`, `activeWatchProviderFilter`: full unit coverage
- filtered-path cases added to `system-list-queries` and `lists` suites (streamable-only results, empty matches, person exclusion, region validation)
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (338), `pnpm fallow`, and `pnpm build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)