### PR TITLE
🐛 Fix pagination scroll starting from the page top on iOS (svh shell floor)

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -131,7 +131,12 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
+          // min-h-lvh, not min-h-svh: the shell's height floor must cover the
+          // *large* viewport (iOS toolbar collapsed). With an svh floor, a
+          // mid-pagination render with little content shrinks the document
+          // below the visible viewport, Safari clamps the scroll to the top,
+          // and the results scroll then visibly runs from the page top.
+          'group/sidebar-wrapper flex min-h-lvh w-full has-data-[variant=inset]:bg-sidebar',
           className,
         )}
         {...props}


### PR DESCRIPTION
## Problem

Follow-up to #283. On iOS Safari, paginating could visibly scroll from the **page top** down to the results instead of from the user's position at the pagination controls.

The reporter's viewport-unit experiment pinpointed it: the behavior appears with an `svh`-based shell and disappears with `lvh`.

## Root cause

The sidebar shell's height floor was `min-h-svh` (small viewport = iOS toolbar expanded). The failure chain:

1. User is at the page bottom at the pagination controls — they scrolled there, so the iOS toolbar is **collapsed** and the visual viewport is the *large* viewport (`lvh`).
2. They tap Next. During the transition the rendered content is momentarily short, so the document height collapses to its floor: `100svh` — **smaller than the current visual viewport**.
3. With nothing to scroll, Safari clamps the scroll position to 0 (top).
4. The new page commits and the scheduled results scroll animates — from the top, down the whole page to `#content`.

## Fix

`min-h-svh` → `min-h-lvh` on the shell wrapper (one class in `src/components/ui/sidebar.tsx`). The document can never become shorter than the collapsed-toolbar viewport, so the scroll position survives the content swap and the results scroll starts from where the user actually was. On desktop `svh` = `lvh`, so nothing changes there. The only tradeoff is the standard `lvh` one: with the toolbar expanded, near-empty pages gain a toolbar's height of scrollable space at the bottom.

## Testing

- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (340 passed), `pnpm fallow` — all green
- `e2e/discover-pagination-scroll.spec.ts` (3×) and the discover nav-menu regression test (3×) pass locally against a prod build with the stubbed TMDB API
- The dynamic-toolbar behavior itself can't be emulated in local Chromium — verification on a real iPhone against the preview is the meaningful check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzzhEyMSBj1B5WisaZghXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzzhEyMSBj1B5WisaZghXx)_