### PR TITLE
🐛 Restore the reading position when the back button returns to a list

### DIFF
--- a/e2e/go-back-scroll.spec.ts
+++ b/e2e/go-back-scroll.spec.ts
@@ -1,0 +1,56 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// The detail pages' deterministic back button pushes the recorded origin URL
+// (src/lib/back-target.ts). A push is a forward navigation and never restores
+// scroll natively, so the recorded reading position is restored explicitly
+// (src/lib/back-scroll.ts). Regression guarded here: without the restore,
+// "go back" from a movie landed at the top of discover — and the next
+// pagination scroll then visibly ran from the page top.
+
+/** Polls `window.scrollY` until it holds steady across ~500ms of reads. */
+async function settledScrollY(page: Page): Promise<number> {
+  let stableReads = 0;
+  let last = Number.NaN;
+
+  for (let i = 0; i < 40; i++) {
+    const y = await page.evaluate(() => Math.round(window.scrollY));
+    stableReads = y === last ? stableReads + 1 : 0;
+    if (stableReads >= 4) return y;
+    last = y;
+    await page.waitForTimeout(120);
+  }
+
+  return last;
+}
+
+test('go back from a movie restores the discover reading position', async ({ page }) => {
+  await page.goto('/discover?page=2');
+  const cards = page.locator('#content a[href^="/movie/"]');
+  await expect(cards.first()).toBeVisible({ timeout: 20_000 });
+
+  // Read from the middle of the list, like a browsing user.
+  await page.evaluate(() =>
+    window.scrollTo({ top: document.body.scrollHeight / 2, behavior: 'instant' }),
+  );
+  const readingPosition = await page.evaluate(() => Math.round(window.scrollY));
+  expect(readingPosition).toBeGreaterThan(200);
+
+  // Click a card that is fully in view, so the click itself doesn't scroll.
+  const visibleIndex = await page.evaluate(() => {
+    const anchors = [...document.querySelectorAll('#content a[href^="/movie/"]')];
+    return anchors.findIndex((anchor) => {
+      const rect = anchor.getBoundingClientRect();
+      return rect.top >= 0 && rect.bottom <= window.innerHeight;
+    });
+  });
+  expect(visibleIndex).toBeGreaterThanOrEqual(0);
+  await cards.nth(visibleIndex).click();
+  await page.waitForURL(/\/movie\//);
+
+  await page.getByRole('button', { name: /go back/i }).click();
+  await page.waitForURL(/\/discover\?page=2/);
+
+  // Lands back at the recorded reading position, not the page top.
+  const restored = await settledScrollY(page);
+  expect(Math.abs(restored - readingPosition)).toBeLessThan(150);
+});

--- a/scripts/migrate-with-db-wait.ts
+++ b/scripts/migrate-with-db-wait.ts
@@ -39,6 +39,12 @@ async function tryConnect() {
 
 async function main() {
   await waitForDatabase(tryConnect, {
+    // Well past the default 60s: a brand-new PR environment's postgres boots
+    // for the first time here (image pull + volume init), which can outlast
+    // the steady-state ~1-3s sleep wake-up by minutes. A pre-deploy can
+    // afford the wait, and a genuinely broken database still fails the
+    // deploy at the deadline.
+    timeoutMs: 5 * 60_000,
     onRetry(error, attempt) {
       const message = error instanceof Error ? error.message : String(error);
       console.warn(`⏳ Database not ready (attempt ${attempt}): ${message}`);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 import { Toaster } from 'sonner';
 
+import { BackScrollRestorer } from '@/components/back-scroll-restorer';
 import { AppSidebarWrapper } from '@/components/app-sidebar-wrapper';
 import { Footer } from '@/components/footer';
 import { LoginToastHandler } from '@/components/login-toast-handler';
@@ -52,6 +53,10 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
                 </SidebarInset>
               </SidebarProvider>
               <LoginToastHandler />
+              {/* usePathname is URL data — needs a boundary under cacheComponents. */}
+              <Suspense fallback={null}>
+                <BackScrollRestorer />
+              </Suspense>
             </PostHogClientProvider>
           </NuqsAdapter>
         </QueryProvider>

--- a/src/components/back-scroll-restorer.tsx
+++ b/src/components/back-scroll-restorer.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { restoreBackScrollIfScheduled } from '@/lib/back-scroll';
+
+/**
+ * Consumes a pending back-navigation scroll restore (see `@/lib/back-scroll`)
+ * once the destination renders. Mounted once in the root layout; keyed on
+ * pathname because the back button always navigates across pathnames.
+ */
+export function BackScrollRestorer() {
+  const pathname = usePathname();
+
+  useEffect(restoreBackScrollIfScheduled, [pathname]);
+
+  return null;
+}

--- a/src/components/go-back.tsx
+++ b/src/components/go-back.tsx
@@ -3,6 +3,8 @@
 import { ChevronLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
+import { scheduleBackScrollRestore } from '@/lib/back-scroll';
+
 import { useBackTarget } from '@/hooks/use-back-target';
 
 import { Button } from './ui/button';
@@ -21,7 +23,12 @@ export function GoBack() {
   return (
     <Button
       onClick={() => {
-        router.push(href);
+        // router.push is a forward navigation and never restores scroll;
+        // schedule restoring the recorded reading position instead. When a
+        // restore is pending, Next's own scroll-to-top must stay off or it
+        // overrides the restored position after the destination commits.
+        const willRestore = scheduleBackScrollRestore(href);
+        router.push(href, { scroll: !willRestore });
       }}
       className="inline-flex items-center gap-2 p-0 text-zinc-400 transition-colors hover:text-white"
       variant="link"

--- a/src/lib/back-scroll.test.ts
+++ b/src/lib/back-scroll.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  clearBackScroll,
   restoreBackScrollIfScheduled,
   saveBackScroll,
   scheduleBackScrollRestore,
@@ -101,6 +102,22 @@ describe('back scroll restore', () => {
 
     scheduleBackScrollRestore('/discover?page=3');
     moveTo('http://app.test/discover?page=3');
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('clearing drops a previously recorded position (explicit back targets)', () => {
+    const { scrollTo } = stubWindow({ url: 'http://app.test/search?q=x', scrollY: 481 });
+
+    saveBackScroll();
+    // The quick-search palette records /search?q=x as an explicit target from
+    // another page — the old reading position must not survive that.
+    moveTo('http://app.test/movie/1');
+    clearBackScroll('/search?q=x');
+
+    expect(scheduleBackScrollRestore('/search?q=x')).toBe(false);
+    moveTo('http://app.test/search?q=x');
     restoreBackScrollIfScheduled();
 
     expect(scrollTo).not.toHaveBeenCalled();

--- a/src/lib/back-scroll.test.ts
+++ b/src/lib/back-scroll.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  restoreBackScrollIfScheduled,
+  saveBackScroll,
+  scheduleBackScrollRestore,
+} from './back-scroll';
+
+function locationFrom(url: string) {
+  const parsed = new URL(url);
+  return { pathname: parsed.pathname, search: parsed.search };
+}
+
+function stubWindow({ url, scrollY = 0 }: { url: string; scrollY?: number }) {
+  const store = new Map<string, string>();
+  const scrollTo = vi.fn();
+  vi.stubGlobal('window', {
+    location: locationFrom(url),
+    scrollY,
+    scrollTo,
+    sessionStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+    },
+    dispatchEvent: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  return { store, scrollTo };
+}
+
+function moveTo(url: string) {
+  (window as unknown as { location: ReturnType<typeof locationFrom> }).location =
+    locationFrom(url);
+}
+
+afterEach(function resetModuleState() {
+  // Drain any schedule left behind so tests stay independent: a render away
+  // from the scheduled destination drops it.
+  stubWindow({ url: 'http://app.test/drain' });
+  restoreBackScrollIfScheduled();
+  vi.unstubAllGlobals();
+});
+
+describe('back scroll restore', () => {
+  it('restores the recorded position at the destination', () => {
+    const { scrollTo } = stubWindow({ url: 'http://app.test/discover?page=2', scrollY: 1500 });
+
+    saveBackScroll();
+    moveTo('http://app.test/movie/1');
+    scheduleBackScrollRestore('/discover?page=2');
+    moveTo('http://app.test/discover?page=2');
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 1500, behavior: 'instant' });
+  });
+
+  it('matches the destination regardless of query parameter order', () => {
+    const { scrollTo } = stubWindow({
+      url: 'http://app.test/discover?mediaType=tv&page=2',
+      scrollY: 900,
+    });
+
+    saveBackScroll();
+    moveTo('http://app.test/movie/1');
+    scheduleBackScrollRestore('/discover?page=2&mediaType=tv');
+    moveTo('http://app.test/discover?mediaType=tv&page=2');
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 900, behavior: 'instant' });
+  });
+
+  it('is one-shot: a second render does not restore again', () => {
+    const { scrollTo } = stubWindow({ url: 'http://app.test/search?q=x', scrollY: 700 });
+
+    saveBackScroll();
+    scheduleBackScrollRestore('/search?q=x');
+    restoreBackScrollIfScheduled();
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the schedule when landing somewhere else', () => {
+    const { scrollTo } = stubWindow({ url: 'http://app.test/discover', scrollY: 1200 });
+
+    saveBackScroll();
+    scheduleBackScrollRestore('/discover');
+    moveTo('http://app.test/watchlist');
+    restoreBackScrollIfScheduled();
+    // Even reaching the destination later must not restore — the stale
+    // schedule was dropped by the unrelated render.
+    moveTo('http://app.test/discover');
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a recorded position', () => {
+    const { scrollTo } = stubWindow({ url: 'http://app.test/discover' });
+
+    scheduleBackScrollRestore('/discover?page=3');
+    moveTo('http://app.test/discover?page=3');
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores a recorded position of zero', () => {
+    const { scrollTo } = stubWindow({ url: 'http://app.test/discover', scrollY: 0 });
+
+    saveBackScroll();
+    scheduleBackScrollRestore('/discover');
+    restoreBackScrollIfScheduled();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/back-scroll.ts
+++ b/src/lib/back-scroll.ts
@@ -45,6 +45,23 @@ export function saveBackScroll() {
 }
 
 /**
+ * Clears any recorded position for {@link href}. Explicit back targets (the
+ * quick-search palette) point at a page the user is not currently reading —
+ * a position recorded on an earlier visit must not be restored for them.
+ */
+export function clearBackScroll(href: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const destination = new URL(href, PARSE_BASE_ORIGIN);
+  writeSessionStorageValue(
+    KEY_PREFIX + identityFrom(destination.pathname, destination.search),
+    '0',
+  );
+}
+
+/**
  * Schedules restoring the recorded position for {@link href}; call right
  * before pushing the back navigation. Returns whether a restore was
  * scheduled — when it was, the caller must push with `scroll: false`, or

--- a/src/lib/back-scroll.ts
+++ b/src/lib/back-scroll.ts
@@ -1,0 +1,79 @@
+// Restores the reading position when the deterministic back button returns
+// to a previously visited page (see `@/lib/back-target`). `router.push` is a
+// forward navigation, so the browser does not restore scroll for it — without
+// this, "go back" from a detail page landed at the page top.
+//
+// The position is recorded alongside the back target when the user clicks
+// into a detail page, keyed by the URL it belongs to. `GoBack` schedules a
+// restore before pushing and `BackScrollRestorer` consumes it once the
+// navigation lands. Like `@/lib/scroll-to-content`, the schedule is scoped
+// to its destination: a render anywhere else drops it.
+
+import { readSessionStorageValue, writeSessionStorageValue } from './session-storage';
+
+const KEY_PREFIX = 'back-scroll:';
+
+/** Order-insensitive pathname + query identity for storage keys. */
+function identityFrom(pathname: string, search: string) {
+  const params = new URLSearchParams(search);
+  params.sort();
+  const query = params.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+function currentIdentity() {
+  return identityFrom(window.location.pathname, window.location.search);
+}
+
+/** Placeholder base for parsing app-relative hrefs; see `./back-target`. */
+const PARSE_BASE_ORIGIN = 'http://internal';
+
+type ScheduledRestore = {
+  identity: string;
+  top: number;
+};
+
+let scheduled: ScheduledRestore | null = null;
+
+/** Records the current scroll position for the current URL. */
+export function saveBackScroll() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  writeSessionStorageValue(KEY_PREFIX + currentIdentity(), String(Math.round(window.scrollY)));
+}
+
+/**
+ * Schedules restoring the recorded position for {@link href}; call right
+ * before pushing the back navigation. Returns whether a restore was
+ * scheduled — when it was, the caller must push with `scroll: false`, or
+ * Next's own navigation scroll resets the page to the top after the restore.
+ */
+export function scheduleBackScrollRestore(href: string) {
+  const destination = new URL(href, PARSE_BASE_ORIGIN);
+  const identity = identityFrom(destination.pathname, destination.search);
+  const top = Number(readSessionStorageValue(KEY_PREFIX + identity));
+
+  scheduled = Number.isFinite(top) && top > 0 ? { identity, top } : null;
+  return scheduled !== null;
+}
+
+/**
+ * Instantly restores the scheduled position if the current location is the
+ * scheduled destination; otherwise drops the schedule. One-shot either way.
+ */
+export function restoreBackScrollIfScheduled() {
+  if (!scheduled) {
+    return;
+  }
+
+  const { identity, top } = scheduled;
+  scheduled = null;
+
+  if (currentIdentity() !== identity) {
+    return;
+  }
+
+  window.scrollTo({ top, behavior: 'instant' });
+}

--- a/src/lib/back-target.ts
+++ b/src/lib/back-target.ts
@@ -1,4 +1,4 @@
-import { saveBackScroll } from './back-scroll';
+import { clearBackScroll, saveBackScroll } from './back-scroll';
 import { writeSessionStorageValue } from './session-storage';
 
 /**
@@ -40,6 +40,10 @@ export function saveBackTarget(href: string, target?: string) {
     // The implicit target is the page the user is looking at right now —
     // record the reading position so the back button can restore it.
     saveBackScroll();
+  } else {
+    // An explicit target points at a page the user is NOT currently reading;
+    // drop any position recorded on an earlier visit so it can't be reused.
+    clearBackScroll(target);
   }
 
   writeSessionStorageValue(

--- a/src/lib/back-target.ts
+++ b/src/lib/back-target.ts
@@ -1,3 +1,4 @@
+import { saveBackScroll } from './back-scroll';
 import { writeSessionStorageValue } from './session-storage';
 
 /**
@@ -33,6 +34,12 @@ export function backTargetKey(href: string) {
 export function saveBackTarget(href: string, target?: string) {
   if (typeof window === 'undefined') {
     return;
+  }
+
+  if (target === undefined) {
+    // The implicit target is the page the user is looking at right now —
+    // record the reading position so the back button can restore it.
+    saveBackScroll();
   }
 
   writeSessionStorageValue(


### PR DESCRIPTION
Replaces #289 — same commits; that PR's Railway preview environment came up with a broken postgres and every deploy failed in the pre-deploy step, so this fresh PR gets a cleanly provisioned environment.

## Problem

Reported as "the pagination scroll-from-top bug is back" on iOS after #284/#285/#286 — but the pagination scroll was fine. The real regression came from **#285's deterministic back button**: `router.push(recordedUrl)` is a *forward* navigation, so the browser never restores scroll for it. "Go back" from a movie landed at the **top** of discover, and the *next* pagination click then correctly scrolled from where the user was — the top — down to the results, which read exactly like the old svh bug.

Reproduced with a scroll-trajectory probe: discover?page=2, reading at 1303px → open a movie → tap "Go back" → **flat scrollY 0** for the full sampling window. It only showed in prod because that's where people browse naturally (into a movie and back before paginating); preview testing exercised pagination directly. Discover-only because GoBack's primary destination is discover — the lists pages have their own back links.

## Fix

Restore the recorded reading position, preserving #285's deterministic-URL design:

- `saveBackTarget` (the click into a detail page) now also records `window.scrollY`, keyed by the origin URL with an order-insensitive query identity (`src/lib/back-scroll.ts`). Explicit-target calls (quick-search palette) instead **invalidate** that URL's recorded position, so a stale offset from an earlier visit can't be restored (review finding).
- `GoBack` schedules a restore before pushing, and pushes with `scroll: false` when a restore is pending — otherwise Next's own navigation scroll resets to the top *after* the restore (observed in the probe). Without a recorded position the push keeps its stock scroll-to-top.
- A tiny `BackScrollRestorer` in the root layout consumes the schedule once the destination renders (pathname-keyed effect; the back button always crosses pathnames). Same destination-scoped one-shot pattern as `src/lib/scroll-to-content.ts`: landing anywhere else drops the schedule.

After the fix the same probe shows the position snap back to 1303px within ~250ms of tapping "Go back".

Also included: the pre-deploy database wait now allows 5 minutes instead of 60s, so a brand-new PR environment's first postgres boot can't fail the deploy.

## Testing

- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (364 passed — 7 new unit tests for record/clear/schedule/restore, including query-order insensitivity, one-shot consumption, abandoned-schedule dropping, and explicit-target invalidation), `pnpm fallow` — all green
- New e2e spec `e2e/go-back-scroll.spec.ts`: scroll mid-list on discover page 2, open a movie, go back, assert the position is restored (±150px)
- `detail-scroll`, `discover-pagination-scroll`, and the discover nav-menu regression specs all pass locally against a prod build with the stubbed TMDB API
- On #289 the identical commits passed full CI (E2E with real TMDB credentials) and three Greptile review passes at 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzzhEyMSBj1B5WisaZghXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzzhEyMSBj1B5WisaZghXx)_