### PR TITLE
🐛 Apply saved streaming providers to discover's client query key

### DIFF
--- a/e2e/discover-pagination-scroll.spec.ts
+++ b/e2e/discover-pagination-scroll.spec.ts
@@ -4,13 +4,12 @@ import { signInAnonymously } from './helpers';
 
 // Paginating scrolls to the top of the results: the click schedules the
 // scroll and PaginationControls performs it once the new page is on screen
-// (see src/lib/scroll-to-content.ts), so the skeleton → results swap can't
-// move the ground under it.
+// (see src/lib/scroll-to-content.ts), so a mid-navigation render can't move
+// the ground under it.
 //
 // This runs under the `mobile-safari` project (WebKit + an iPhone viewport) —
 // the engine and form factor where click-time scrolling historically lost the
-// scroll. The discover data is deliberately delayed so the swap happens well
-// after the click, the timing that used to break.
+// scroll.
 //
 // Invariant: after paginating from a scrolled-down position, the viewport
 // settles at the top of `#content` (its first item, minus the
@@ -49,16 +48,6 @@ function firstCardHref(page: Page): Promise<string> {
 }
 
 test('paginating lands at the top of the results, not the page top', async ({ page }) => {
-  // Delay the discover server action so the next page's results swap in while
-  // the scroll is still animating — the timing that dropped the scroll on
-  // Safari. The initial page load is a GET and is unaffected.
-  await page.route('**/discover**', async (route) => {
-    if (route.request().method() === 'POST') {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-    await route.continue();
-  });
-
   await page.goto('/discover');
   const container = page.locator('#content');
   const firstCard = container.locator('a[href^="/movie/"]').first();

--- a/e2e/discover-pagination-scroll.spec.ts
+++ b/e2e/discover-pagination-scroll.spec.ts
@@ -1,5 +1,7 @@
 import { expect, type Page, test } from '@playwright/test';
 
+import { signInAnonymously } from './helpers';
+
 // Paginating scrolls to the top of the results: the click schedules the
 // scroll and PaginationControls performs it once the new page is on screen
 // (see src/lib/scroll-to-content.ts), so the skeleton → results swap can't
@@ -101,6 +103,73 @@ test('paginating lands at the top of the results, not the page top', async ({ pa
 
   // Lands on the results (top of the first item, minus the small scroll-margin
   // gap) — not yanked to the page top (the bug) and not left far down the page.
+  expect(finalY).toBeGreaterThan(containerTop - SCROLL_MARGIN - 60);
+  expect(finalY).toBeLessThan(containerTop + 60);
+});
+
+// Users with saved streaming services hit a different data path on a bare
+// /discover URL: the server prefetches with their saved providers while the
+// client hook derives its React Query key from the URL alone. When those
+// disagreed, the dehydrated data was orphaned and every navigation re-fetched
+// client-side with the wrong (major-providers) filter — skeleton swaps, a
+// vanishing pagination bar, and pagination scrolling from the page top
+// instead of from where the user was. With the client pinned to the server's
+// provider fallback, the keys match and each page arrives once, already
+// hydrated: no client re-fetch ever fires.
+test('pagination for a user with saved providers stays on the hydrated data', async ({
+  page,
+}) => {
+  await signInAnonymously(page, '/settings');
+  await page
+    .getByRole('button')
+    .filter({ has: page.getByText('Netflix', { exact: true }) })
+    .first()
+    .click();
+  await page.getByRole('button', { name: 'Save Preferences' }).click();
+  await expect(page.getByText('Preferences saved!')).toBeVisible({ timeout: 15_000 });
+
+  // Client-side discover re-fetches are server-action POSTs. None may happen:
+  // a POST here means the client's React Query key missed the data the server
+  // prefetched and dehydrated — the provider-fallback mismatch this test pins.
+  const actionPosts: string[] = [];
+  page.on('request', (request) => {
+    if (request.method() === 'POST' && request.url().includes('/discover')) {
+      actionPosts.push(request.postData() ?? '');
+    }
+  });
+
+  await page.goto('/discover');
+  const firstCard = page.locator('#content a[href^="/movie/"]').first();
+  await expect(firstCard).toBeVisible({ timeout: 20_000 });
+  const firstHrefBefore = await firstCardHref(page);
+
+  const containerTop = await page.evaluate(() => {
+    const el = document.querySelector('#content')!;
+    return Math.round(el.getBoundingClientRect().top + window.scrollY);
+  });
+  await page.evaluate(() =>
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' }),
+  );
+
+  await page.getByRole('button', { name: /go to next page/i }).click();
+  await page.waitForURL(/page=2/);
+  await expect
+    .poll(
+      async () => {
+        const href = await firstCardHref(page);
+        return href !== '' && href !== firstHrefBefore;
+      },
+      { timeout: 20_000 },
+    )
+    .toBe(true);
+
+  // Both the initial load and the pagination were served by the dehydrated
+  // server prefetch — the client never had to re-fetch.
+  expect(actionPosts).toHaveLength(0);
+
+  // And the scroll invariant holds on this path too: settle at the top of the
+  // results, not the page top.
+  const finalY = await settledScrollY(page);
   expect(finalY).toBeGreaterThan(containerTop - SCROLL_MARGIN - 60);
   expect(finalY).toBeLessThan(containerTop + 60);
 });

--- a/src/app/discover/[[...genreId]]/discover-content.tsx
+++ b/src/app/discover/[[...genreId]]/discover-content.tsx
@@ -8,7 +8,10 @@ import { GenreNavigationClient } from '@/components/genre-navigation-client';
 import MediaTypeSelector from '@/components/media-type-selector';
 import SectionTitle from '@/components/section-title';
 import SkipToElement from '@/components/skip-to-element';
-import { parseAsPipeSeparatedArrayOfIntegers } from '@/lib/watch-provider-search-params';
+import {
+  getWatchProvidersString,
+  parseAsPipeSeparatedArrayOfIntegers,
+} from '@/lib/watch-provider-search-params';
 import type { Genre } from '@/types/genre';
 import { WatchProvider } from '@/types/watch-provider';
 
@@ -17,6 +20,7 @@ import Pagination from './pagination';
 type DiscoverContentProps = {
   filteredWatchProviders: WatchProvider[];
   userRegion: string;
+  userWatchProviders: number[];
   movieGenres: Genre[];
   tvGenres: Genre[];
   userId?: string;
@@ -32,7 +36,7 @@ type DiscoverViewState = {
   runtimeLte?: number;
 };
 
-function useDiscoverViewState(userRegion: string): DiscoverViewState {
+function useDiscoverViewState(userRegion: string, userWatchProviders: number[]): DiscoverViewState {
   const [urlState] = useQueryStates(
     {
       page: parseAsInteger.withDefault(1),
@@ -56,7 +60,13 @@ function useDiscoverViewState(userRegion: string): DiscoverViewState {
     genreId: urlState.genreId,
     mediaType: urlState.mediaType,
     sortBy: urlState.sort_by,
-    watchProviders: urlState.with_watch_providers?.join('|'),
+    // Same fallback the server prefetch applies (URL selection, else the
+    // user's saved providers): a different value here changes the React Query
+    // key, orphans the dehydrated data, and refetches with the wrong filter.
+    watchProviders: getWatchProvidersString(
+      urlState.with_watch_providers ?? [],
+      userWatchProviders,
+    ),
     watchRegion: urlState.watch_region ?? userRegion,
     runtimeLte: urlState.runtimeLte ?? undefined,
   };
@@ -133,12 +143,13 @@ function DiscoverResults({
 export function DiscoverContent({
   filteredWatchProviders,
   userRegion,
+  userWatchProviders,
   movieGenres,
   tvGenres,
   userId,
 }: DiscoverContentProps) {
   const { page, genreId, mediaType, sortBy, watchProviders, watchRegion, runtimeLte } =
-    useDiscoverViewState(userRegion);
+    useDiscoverViewState(userRegion, userWatchProviders);
   const genres = mediaType === 'movie' ? movieGenres : tvGenres;
 
   return (

--- a/src/app/discover/[[...genreId]]/page.tsx
+++ b/src/app/discover/[[...genreId]]/page.tsx
@@ -101,6 +101,7 @@ export default async function DiscoverWithGenrePage(props: DiscoverWithGenrePara
       <DiscoverContent
         filteredWatchProviders={filteredWatchProviders}
         userRegion={watchRegion}
+        userWatchProviders={userWatchProviders}
         userId={user?.id}
         movieGenres={movieGenres}
         tvGenres={tvGenres}

--- a/src/components/pagination-controls.tsx
+++ b/src/components/pagination-controls.tsx
@@ -83,8 +83,8 @@ export function PaginationControls({ totalPages }: PaginationControlsProps) {
   // links' onNavigate, which skips modifier/middle clicks that open a new
   // tab); it runs here once the new page is on screen — when this instance
   // re-renders with the new page number, or when a fresh instance mounts
-  // after a `<Suspense key={page}>` boundary swapped the tree during the
-  // navigation.
+  // after a loading state (e.g. discover's spinner) swapped the controls out
+  // during the navigation.
   useEffect(scrollToContentIfScheduled, [currentPageNumber]);
 
   function buildPageHref(page: number) {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -133,9 +133,10 @@ function SidebarProvider({
         className={cn(
           // min-h-lvh, not min-h-svh: the shell's height floor must cover the
           // *large* viewport (iOS toolbar collapsed). With an svh floor, a
-          // mid-pagination render with little content shrinks the document
-          // below the visible viewport, Safari clamps the scroll to the top,
-          // and the results scroll then visibly runs from the page top.
+          // mid-navigation render with little content (a loading skeleton)
+          // shrinks the document below the visible viewport, Safari clamps
+          // the scroll to the top, and a scheduled scroll or back-position
+          // restore then visibly runs from the page top.
           'group/sidebar-wrapper flex min-h-lvh w-full has-data-[variant=inset]:bg-sidebar',
           className,
         )}

--- a/src/lib/scroll-to-content.ts
+++ b/src/lib/scroll-to-content.ts
@@ -1,11 +1,11 @@
 // Coordinates "paginate, then scroll to the top of the results".
 //
-// The scroll can't happen at click time: the new page renders later (often
-// behind a `<Suspense key={page}>` fallback) and the document height changes
-// under an early scroll. Instead the click schedules the scroll here and
-// PaginationControls performs it in an effect once the new page is on screen.
-// Module state rather than React state: the Suspense swap remounts the
-// controls, which would lose anything stored in the component.
+// The scroll can't happen at click time: the new page renders later and the
+// document height changes under an early scroll. Instead the click schedules
+// the scroll here and PaginationControls performs it in an effect once the
+// new page is on screen. Module state rather than React state: a loading
+// state can swap the controls out during the navigation (e.g. discover's
+// spinner), and a remount would lose anything stored in the component.
 //
 // The schedule is scoped to the navigation's destination so it can't leak: a
 // later render anywhere else (the navigation was abandoned or superseded)


### PR DESCRIPTION
## Why

The pagination scroll bug that survived #283/#290 only reproduced on accounts with **custom streaming providers** — it worked logged out and for fresh accounts. Root cause:

- The discover **server page** prefetches with the effective provider filter: URL selection, else the user's **saved providers** (`getWatchProvidersString`).
- The **client hook** (`useDiscoverViewState`) derived its React Query key from the **URL alone**.

For a provider user on a bare `/discover` URL the two keys never match. The dehydrated prefetch is orphaned, and every navigation re-fetches client-side with **no provider argument** — which the server then falls back to the *major-providers* list for. Verified against a local TMDB mock (user with saved providers `8|337`, one pagination click):

```
before: /discover/movie?page=2&…&with_watch_providers=8|337            ← RSC prefetch (orphaned)
        /discover/movie?page=2&…&with_watch_providers=8|337|119|350|…  ← client re-fetch (wrong filter, rendered)
after:  /discover/movie?page=2&…&with_watch_providers=8|337            ← single flight, hydrated
```

Consequences of the mismatch:

1. **Saved provider filtering was silently ignored** — the grid rendered major-providers results.
2. Every pagination went through a skeleton + pagination-spinner phase (`PaginationControls` unmounts mid scroll choreography) plus a duplicate TMDB fetch — on iOS Safari this is where the "scrolls from the page top instead of from where I was" symptom lives. Accounts without saved providers have matching keys, ride the hydrated data, and never see it.

## What

- `discover-content.tsx` now derives the provider filter with the **same fallback the server uses**: `getWatchProvidersString(urlProviders, userWatchProviders)`; the page passes the saved providers down. Keys match for every account shape, so each page's data arrives once via the dehydrated prefetch.
- E2E regression (runs under the `mobile-safari` project): sign in, save Netflix in settings, paginate on `/discover`, assert **zero client discover re-fetches** (server-action POSTs) and that the scroll still settles at the top of the results. Validated both ways locally: fails on the old code (2 POSTs with `"$undefined"` providers), passes with the fix.

## Verification

- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (364 passing), `pnpm fallow` — all green.
- Full local e2e suite against a prod build + TMDB mock: 47/48 green (the one failure is `imgproxy.spec.ts`, which needs external network egress this sandbox blocks — unrelated).
- Scroll trajectory probes (iPhone-13 viewport, 1.5 s simulated TMDB latency for provider-filtered requests): pagination holds the reader's position and smooth-scrolls to the results top, now in half the time (single fetch instead of two serial ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzzhEyMSBj1B5WisaZghXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzzhEyMSBj1B5WisaZghXx)_