### PR TITLE
Make the app header sticky

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,13 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, architecture, and convention
 - If fallow finds duplicate code, but the abstraction to merge the code does not make sens, use suppression
 - Prefer normal functions over arrows except inline.
 - Server-only modules import `server-only`; keep secrets and DB access out of client components.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/e2e/discover-pagination-scroll.spec.ts
+++ b/e2e/discover-pagination-scroll.spec.ts
@@ -14,8 +14,34 @@ import { signInAnonymously } from './helpers';
 // Invariant: after paginating from a scrolled-down position, the viewport
 // settles at the top of `#content` (its first item, minus the
 // `scroll-m-5` gap), not at the page top.
+//
+// The header is sticky, so the root's `scroll-padding-top` holds `#content`
+// clear of it — the resting offset is that much further up the document than
+// the container's own position. Measured rather than hardcoded so the header
+// and this test can't drift apart.
 
 const SCROLL_MARGIN = 20; // scroll-m-5 on #content (1.25rem)
+
+/** Height of the sticky header, which the root scroll-padding reserves. */
+function headerHeight(page: Page): Promise<number> {
+  return page.evaluate(() =>
+    Math.round(document.querySelector('header')?.getBoundingClientRect().height ?? 0),
+  );
+}
+
+/**
+ * Asserts the settled scroll position rests at the top of the results: below
+ * the sticky header, not yanked to the page top and not left down the page.
+ *
+ * @param finalY - The settled `window.scrollY`.
+ * @param containerTop - `#content`'s document offset, measured at rest.
+ * @param header - The sticky header's height.
+ */
+function expectRestingAtResultsTop(finalY: number, containerTop: number, header: number) {
+  const expectedY = containerTop - header - SCROLL_MARGIN;
+  expect(finalY).toBeGreaterThan(expectedY - 60);
+  expect(finalY).toBeLessThan(expectedY + 60);
+}
 
 /**
  * Polls `window.scrollY` until it holds steady, so we measure where the scroll
@@ -59,6 +85,7 @@ test('paginating lands at the top of the results, not the page top', async ({ pa
     const el = document.querySelector('#content')!;
     return Math.round(el.getBoundingClientRect().top + window.scrollY);
   });
+  const header = await headerHeight(page);
 
   // Remember page 1's first result so we can tell when page 2 has swapped in.
   const firstHrefBefore = await firstCardHref(page);
@@ -92,8 +119,7 @@ test('paginating lands at the top of the results, not the page top', async ({ pa
 
   // Lands on the results (top of the first item, minus the small scroll-margin
   // gap) — not yanked to the page top (the bug) and not left far down the page.
-  expect(finalY).toBeGreaterThan(containerTop - SCROLL_MARGIN - 60);
-  expect(finalY).toBeLessThan(containerTop + 60);
+  expectRestingAtResultsTop(finalY, containerTop, header);
 });
 
 // Users with saved streaming services hit a different data path on a bare
@@ -136,6 +162,7 @@ test('pagination for a user with saved providers stays on the hydrated data', as
     const el = document.querySelector('#content')!;
     return Math.round(el.getBoundingClientRect().top + window.scrollY);
   });
+  const header = await headerHeight(page);
   await page.evaluate(() =>
     window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' }),
   );
@@ -159,6 +186,5 @@ test('pagination for a user with saved providers stays on the hydrated data', as
   // And the scroll invariant holds on this path too: settle at the top of the
   // results, not the page top.
   const finalY = await settledScrollY(page);
-  expect(finalY).toBeGreaterThan(containerTop - SCROLL_MARGIN - 60);
-  expect(finalY).toBeLessThan(containerTop + 60);
+  expectRestingAtResultsTop(finalY, containerTop, header);
 });

--- a/e2e/sticky-header.spec.ts
+++ b/e2e/sticky-header.spec.ts
@@ -102,6 +102,45 @@ test('the sidebar trigger stays clickable once the page is scrolled', async ({ p
   await expect(page.locator('nav').first()).toBeVisible();
 });
 
+test('page content scrolls behind the header, never over it', async ({ page }) => {
+  // Regression: cards decorate themselves with z-index (the trending card's
+  // title overlay is z-10, sortable cards' drag badges z-20). With no stacking
+  // context between them and the header, those competed with the header's own
+  // z-index directly and won on DOM order — titles rendered straight through
+  // the header while scrolling. Home is the page that showed it: its trending
+  // cards sit at the top, so they pass under the header immediately.
+  await page.goto('/');
+  const overlayTitle = page.locator('a[href^="/movie/"] h2, a[href^="/tv/"] h2').first();
+  await expect(overlayTitle).toBeVisible({ timeout: 20_000 });
+
+  // Park an overlay title inside the header's band rather than guessing a
+  // scroll offset — the whole point is what paints where they intersect.
+  const header = page.locator('header');
+  const headerBox = (await header.boundingBox())!;
+  const titleBox = (await overlayTitle.boundingBox())!;
+  await page.evaluate(
+    ([titleTop, headerHeight]) =>
+      window.scrollTo({ top: titleTop - headerHeight / 2, behavior: 'instant' }),
+    [titleBox.y, headerBox.height],
+  );
+  await page.waitForTimeout(100);
+
+  // Hit-test across the header: whatever is topmost at each point has to be the
+  // header or something inside it. A leaked overlay reports the card instead.
+  const topmost = await page.evaluate(() => {
+    const el = document.querySelector('header')!;
+    const rect = el.getBoundingClientRect();
+    const y = Math.round(rect.top + rect.height / 2);
+    return [0.15, 0.35, 0.5, 0.65, 0.85].map((fraction) => {
+      const hit = document.elementFromPoint(Math.round(window.innerWidth * fraction), y);
+      if (!hit) return 'nothing';
+      return el.contains(hit) ? 'header' : (hit.tagName.toLowerCase() + '.' + hit.className);
+    });
+  });
+
+  expect(topmost).toEqual(['header', 'header', 'header', 'header', 'header']);
+});
+
 test('the skip link lands the content below the header, not behind it', async ({ page }) => {
   await page.goto('/discover');
   await expect(page.locator('#content a[href^="/movie/"]').first()).toBeVisible({

--- a/e2e/sticky-header.spec.ts
+++ b/e2e/sticky-header.spec.ts
@@ -113,32 +113,37 @@ test('page content scrolls behind the header, never over it', async ({ page }) =
   const overlayTitle = page.locator('a[href^="/movie/"] h2, a[href^="/tv/"] h2').first();
   await expect(overlayTitle).toBeVisible({ timeout: 20_000 });
 
-  // Park an overlay title inside the header's band rather than guessing a
-  // scroll offset — the whole point is what paints where they intersect.
-  const header = page.locator('header');
-  const headerBox = (await header.boundingBox())!;
-  const titleBox = (await overlayTitle.boundingBox())!;
-  await page.evaluate(
-    ([titleTop, headerHeight]) =>
-      window.scrollTo({ top: titleTop - headerHeight / 2, behavior: 'instant' }),
-    [titleBox.y, headerBox.height],
-  );
-  await page.waitForTimeout(100);
+  // Scan the page rather than parking at one offset. Different things cross the
+  // header at different scroll positions — trending titles near the top, the
+  // sliders' arrows and edge fades further down — and hit-testing a single spot
+  // only ever catches whatever happened to be there. `elementFromPoint` also
+  // reports fully transparent elements, so this catches an invisible control
+  // sitting over the header, not just a visible one.
+  const leaks = await page.evaluate(() => {
+    const header = document.querySelector('header')!;
+    const found: { scrollY: number; hit: string }[] = [];
+    const step = Math.round(window.innerHeight / 3);
 
-  // Hit-test across the header: whatever is topmost at each point has to be the
-  // header or something inside it. A leaked overlay reports the card instead.
-  const topmost = await page.evaluate(() => {
-    const el = document.querySelector('header')!;
-    const rect = el.getBoundingClientRect();
-    const y = Math.round(rect.top + rect.height / 2);
-    return [0.15, 0.35, 0.5, 0.65, 0.85].map((fraction) => {
-      const hit = document.elementFromPoint(Math.round(window.innerWidth * fraction), y);
-      if (!hit) return 'nothing';
-      return el.contains(hit) ? 'header' : (hit.tagName.toLowerCase() + '.' + hit.className);
-    });
+    for (let top = 0; top < document.body.scrollHeight; top += step) {
+      window.scrollTo({ top, behavior: 'instant' });
+      const rect = header.getBoundingClientRect();
+      const y = Math.round(rect.top + rect.height / 2);
+
+      for (const fraction of [0.1, 0.3, 0.5, 0.7, 0.9]) {
+        const hit = document.elementFromPoint(Math.round(window.innerWidth * fraction), y);
+        if (hit && !header.contains(hit)) {
+          found.push({
+            scrollY: Math.round(window.scrollY),
+            hit: `${hit.tagName.toLowerCase()}.${String(hit.className).split(' ').slice(0, 3).join('.')}`,
+          });
+        }
+      }
+    }
+
+    return found;
   });
 
-  expect(topmost).toEqual(['header', 'header', 'header', 'header', 'header']);
+  expect(leaks).toEqual([]);
 });
 
 test('the skip link lands the content below the header, not behind it', async ({ page }) => {

--- a/e2e/sticky-header.spec.ts
+++ b/e2e/sticky-header.spec.ts
@@ -1,0 +1,126 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { MOVIE_PATH } from './helpers';
+
+// The root layout's header (sidebar trigger + search) is sticky. Three things
+// have to hold, and all three are invisible on a page short enough not to
+// scroll — hence the explicit long-page routes below.
+//
+// 1. It actually sticks. `position: sticky` resolves against the nearest
+//    scrolling ancestor, and the header's parent (`SidebarInset`) sets
+//    `overflow-x`. With `hidden` that parent becomes a scroll container which
+//    never scrolls, and the header silently rides the page instead of pinning
+//    — it looks fine at the top of the page and only breaks once you scroll.
+//    `overflow-x-clip` keeps the viewport as the scrollport.
+// 2. Nothing lands behind it. `scroll-padding-top` on the root reserves its
+//    height, so anchor jumps and `scrollIntoView` stop below the header.
+// 3. It stays usable. Pinned but non-interactive (a stacking-order slip against
+//    the sidebar or page content) would be the same bug from the user's side.
+//
+// This runs under both projects — desktop Chromium and WebKit on an iPhone
+// viewport — because sticky positioning and scroll-anchoring are exactly where
+// mobile Safari has historically diverged.
+
+/** The sticky header's viewport rect, or null if it isn't rendered. */
+function headerRect(page: Page) {
+  return page.evaluate(() => {
+    const header = document.querySelector('header');
+    if (!header) {
+      return null;
+    }
+
+    const { top, height } = header.getBoundingClientRect();
+    return { top: Math.round(top), height: Math.round(height) };
+  });
+}
+
+/** Scrolls to the bottom of the document without smooth-scroll animation. */
+async function scrollToBottom(page: Page) {
+  await page.evaluate(() =>
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' }),
+  );
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(200);
+}
+
+test('the header stays pinned to the top of the viewport while scrolling', async ({ page }) => {
+  // Discover is reliably taller than any viewport we test at.
+  await page.goto('/discover');
+  await expect(page.locator('#content a[href^="/movie/"]').first()).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const atRest = await headerRect(page);
+  expect(atRest).not.toBeNull();
+  expect(atRest!.top).toBe(0);
+  expect(atRest!.height).toBeGreaterThan(0);
+
+  await scrollToBottom(page);
+
+  // The whole point: still at the top of the viewport, same height. A header
+  // that scrolled away would report a large negative `top`.
+  const afterScroll = await headerRect(page);
+  expect(afterScroll).toEqual(atRest);
+});
+
+test('the header stays pinned on a detail page', async ({ page }) => {
+  // Detail routes stream in behind a loading skeleton, so the header is sticky
+  // across a content swap rather than a single static render.
+  await page.goto(MOVIE_PATH);
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15_000 });
+
+  await scrollToBottom(page);
+
+  const rect = await headerRect(page);
+  expect(rect).not.toBeNull();
+  expect(rect!.top).toBe(0);
+});
+
+test('the search trigger stays clickable once the page is scrolled', async ({ page }) => {
+  await page.goto('/discover');
+  const searchTrigger = page.getByRole('button', { name: /search/i }).first();
+  await expect(searchTrigger).toBeVisible({ timeout: 20_000 });
+
+  await scrollToBottom(page);
+
+  // Not `force: true` — an ordinary click fails if anything overlaps the
+  // header, which is precisely the stacking-order regression worth catching.
+  await searchTrigger.click();
+  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+});
+
+test('the sidebar trigger stays clickable once the page is scrolled', async ({ page }) => {
+  await page.goto('/discover');
+  await expect(page.locator('#content a[href^="/movie/"]').first()).toBeVisible({
+    timeout: 20_000,
+  });
+
+  await scrollToBottom(page);
+
+  const sidebarTrigger = page.getByRole('button', { name: /toggle sidebar/i }).first();
+  await expect(sidebarTrigger).toBeVisible();
+  await sidebarTrigger.click();
+  await expect(page.locator('nav').first()).toBeVisible();
+});
+
+test('the skip link lands the content below the header, not behind it', async ({ page }) => {
+  await page.goto('/discover');
+  await expect(page.locator('#content a[href^="/movie/"]').first()).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // The skip link is visually hidden until focused; Tab from the document start
+  // reaches it the way a keyboard user would.
+  const skipLink = page.getByRole('link', { name: /skip to content/i });
+  await skipLink.focus();
+  await skipLink.press('Enter');
+
+  const header = await headerRect(page);
+  const contentTop = await page.evaluate(() =>
+    Math.round(document.getElementById('content')!.getBoundingClientRect().top),
+  );
+
+  // Below the header (the regression is `contentTop < header.height`, i.e. the
+  // first row of results hidden underneath it) and still near the top.
+  expect(contentTop).toBeGreaterThanOrEqual(header!.height);
+  expect(contentTop).toBeLessThan(header!.height + 80);
+});

--- a/e2e/sticky-header.spec.ts
+++ b/e2e/sticky-header.spec.ts
@@ -122,15 +122,25 @@ test('page content scrolls behind the header, never over it', async ({ page }) =
   const leaks = await page.evaluate(() => {
     const header = document.querySelector('header')!;
     const found: { scrollY: number; hit: string }[] = [];
-    const step = Math.round(window.innerHeight / 3);
+    // Step size decides what this can catch, and the margin is not generous: a
+    // card's title strip is only ~40px tall, so it is inside the header's band
+    // for a correspondingly short run of scroll offsets. Measured against a
+    // deliberately broken build, 100px caught only the slider arrows, 60px
+    // added the year line, and 24px was the first that caught the card title
+    // itself — the element that actually regressed. Keep it small.
+    const STEP = 24;
 
-    for (let top = 0; top < document.body.scrollHeight; top += step) {
+    for (let top = 0; top < document.body.scrollHeight; top += STEP) {
       window.scrollTo({ top, behavior: 'instant' });
       const rect = header.getBoundingClientRect();
       const y = Math.round(rect.top + rect.height / 2);
 
-      for (const fraction of [0.1, 0.3, 0.5, 0.7, 0.9]) {
-        const hit = document.elementFromPoint(Math.round(window.innerWidth * fraction), y);
+      // Sample across the header's own box, not the window's. On desktop the
+      // sidebar occupies the left of the viewport, and it is *supposed* to be
+      // topmost there — it is fixed at z-10 and forms its own stacking context.
+      for (const fraction of [0.05, 0.25, 0.5, 0.75, 0.95]) {
+        const x = Math.round(rect.left + rect.width * fraction);
+        const hit = document.elementFromPoint(x, y);
         if (hit && !header.contains(hit)) {
           found.push({
             scrollY: Math.round(window.scrollY),

--- a/e2e/sticky-header.spec.ts
+++ b/e2e/sticky-header.spec.ts
@@ -156,6 +156,32 @@ test('page content scrolls behind the header, never over it', async ({ page }) =
   expect(leaks).toEqual([]);
 });
 
+test('the page never scrolls horizontally', async ({ page }) => {
+  // Regression from making the header sticky. `SidebarInset` had to move from
+  // `overflow-x: hidden` to `clip` so it stops being a scroll container and the
+  // header sticks to the viewport. But a flex item's `min-width: auto` resolves
+  // to its min-content width *except* on scroll containers, where it resolves
+  // to 0 — so `hidden` had been making the inset shrink correctly for free.
+  // Under `clip` it refused to shrink past its content and pushed the desktop
+  // layout 96px wider than the viewport. `min-w-0` restores it.
+  //
+  // Nothing else here would catch that: the header still pinned, still took
+  // clicks, and nothing painted over it. It was only visible as a horizontal
+  // scrollbar and captions running off the right edge.
+  for (const path of ['/', '/discover']) {
+    await page.goto(path);
+    await expect(page.locator('header')).toBeVisible({ timeout: 20_000 });
+
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+
+    // Sub-pixel rounding can add a stray pixel; anything beyond that is real.
+    expect(scrollWidth, `${path} overflows horizontally`).toBeLessThanOrEqual(clientWidth + 1);
+  }
+});
+
 test('the skip link lands the content below the header, not behind it', async ({ page }) => {
   await page.goto('/discover');
   await expect(page.locator('#content a[href^="/movie/"]').first()).toBeVisible({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,10 +32,11 @@ export default defineConfig({
     },
     {
       // WebKit (the Safari engine) on an iPhone viewport, scoped to the mobile
-      // Safari scroll regression.
+      // Safari scroll regression and the sticky header (which also runs under
+      // chromium — sticky positioning is where the two engines diverge).
       name: 'mobile-safari',
       use: { ...devices['iPhone 13'] },
-      testMatch: /discover-pagination-scroll\.spec\.ts/,
+      testMatch: /(discover-pagination-scroll|sticky-header)\.spec\.ts/,
     },
   ],
   // Build + start the real app unless we were pointed at an external URL.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,9 @@
 
 @theme {
   --breakpoint-desktop: 1024px;
+  /* Height of the sticky app header in src/app/layout.tsx. Single source for
+     both the header's own height and the scroll-padding below. */
+  --header-height: 4rem;
   --container-8xl: 66rem;
   /*--container-9xl: 75rem;
   --container-10xl: 82.5rem;*/
@@ -191,6 +194,13 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+  }
+  html {
+    /* The header is sticky, so the top of the scrollport is behind it. Reserve
+       its height here and every scroll into view — anchor jumps (`#content`
+       skip links), `scrollIntoView` after pagination — stops below it instead
+       of behind it. Targets keep their own `scroll-m-*` as the visible gap. */
+    scroll-padding-top: var(--header-height);
   }
   body {
     @apply bg-background text-foreground;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,20 +59,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
                     <Separator orientation="vertical" className="h-4" />
                     <SearchCommand />
                   </header>
-                  {/*
-                    `isolate` so page content can't paint over the sticky
-                    header. Cards decorate themselves with z-index (title
-                    overlays, drag badges) and, without a stacking context here,
-                    those values compete with the header's directly — a card's
-                    z-10 title beat the header's z-10 on DOM order and showed
-                    through it while scrolling. Containing them means content
-                    can use whatever z-index it likes and never escape the page
-                    area. Dialogs and sheets portal to <body>, so they are not
-                    descendants of this element and still overlay the header.
-                  */}
-                  <div className="isolate mx-auto w-full max-w-7xl px-4 py-4 sm:px-6">
-                    {children}
-                  </div>
+                  <div className="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6">{children}</div>
                   <Footer />
                 </SidebarInset>
               </SidebarProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,15 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
               <SidebarProvider>
                 <AppSidebarWrapper />
                 <SidebarInset>
-                  <header className="px flex h-16 shrink-0 items-center gap-4 border-b px-4">
+                  {/*
+                    Sticky so search stays reachable while scrolling. Needs an
+                    opaque background (content scrolls underneath) and a z-index
+                    above the page but below the sidebar rail (z-20). Its height
+                    is `--header-height`, which globals.css also uses as the
+                    root scroll-padding so anchor jumps and `scrollIntoView`
+                    land below it rather than behind it.
+                  */}
+                  <header className="sticky top-0 z-10 flex h-(--header-height) shrink-0 items-center gap-4 border-b bg-background px-4">
                     <SidebarTrigger className="-ml-1" />
                     <Separator orientation="vertical" className="h-4" />
                     <SearchCommand />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,18 +45,34 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
                 <SidebarInset>
                   {/*
                     Sticky so search stays reachable while scrolling. Needs an
-                    opaque background (content scrolls underneath) and a z-index
-                    above the page but below the sidebar rail (z-20). Its height
-                    is `--header-height`, which globals.css also uses as the
-                    root scroll-padding so anchor jumps and `scrollIntoView`
-                    land below it rather than behind it.
+                    opaque background, since content scrolls underneath. Its
+                    height is `--header-height`, which globals.css also uses as
+                    the root scroll-padding so anchor jumps and `scrollIntoView`
+                    land below it rather than behind it. The z-index only has to
+                    clear the page content below, which the `isolate` on that
+                    wrapper already contains; the desktop sidebar is `fixed
+                    z-10`, so it forms its own stacking context and stays above
+                    this regardless.
                   */}
                   <header className="sticky top-0 z-10 flex h-(--header-height) shrink-0 items-center gap-4 border-b bg-background px-4">
                     <SidebarTrigger className="-ml-1" />
                     <Separator orientation="vertical" className="h-4" />
                     <SearchCommand />
                   </header>
-                  <div className="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6">{children}</div>
+                  {/*
+                    `isolate` so page content can't paint over the sticky
+                    header. Cards decorate themselves with z-index (title
+                    overlays, drag badges) and, without a stacking context here,
+                    those values compete with the header's directly — a card's
+                    z-10 title beat the header's z-10 on DOM order and showed
+                    through it while scrolling. Containing them means content
+                    can use whatever z-index it likes and never escape the page
+                    area. Dialogs and sheets portal to <body>, so they are not
+                    descendants of this element and still overlay the header.
+                  */}
+                  <div className="isolate mx-auto w-full max-w-7xl px-4 py-4 sm:px-6">
+                    {children}
+                  </div>
                   <Footer />
                 </SidebarInset>
               </SidebarProvider>

--- a/src/app/trending.tsx
+++ b/src/app/trending.tsx
@@ -38,7 +38,11 @@ async function Trending({ index, type }: TrendingCardProp) {
   return (
     <BackTargetLink
       href={href}
-      className={`group relative h-52 overflow-hidden rounded-xl border ${borderColor} transition-all hover:scale-[1.02] focus:scale-[1.02] focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-black focus:outline-none lg:h-72 lg:flex-1`}
+      // `isolate`: the title overlay below stacks above this card's backdrop,
+      // which is a card-internal concern. Without a stacking context here that
+      // z-index competes with the sticky header's and wins on DOM order, so the
+      // title paints through the header as the card scrolls under it.
+      className={`group relative isolate h-52 overflow-hidden rounded-xl border ${borderColor} transition-all hover:scale-[1.02] focus:scale-[1.02] focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-black focus:outline-none lg:h-72 lg:flex-1`}
     >
       {resource.backdrop_path && (
         <Imgproxy
@@ -74,7 +78,7 @@ async function Trending({ index, type }: TrendingCardProp) {
 
 Trending.Skeleton = function TrendingSkeleton() {
   return (
-    <div className="relative h-52 animate-pulse overflow-hidden rounded-xl bg-neutral-50/10 lg:h-72 lg:flex-1">
+    <div className="relative isolate h-52 animate-pulse overflow-hidden rounded-xl bg-neutral-50/10 lg:h-72 lg:flex-1">
       <div className="absolute right-0 bottom-0 left-0 z-10 flex h-12 flex-col justify-center bg-zinc-950/10 px-3 py-2"></div>
     </div>
   );

--- a/src/components/sortable-item-card.tsx
+++ b/src/components/sortable-item-card.tsx
@@ -44,7 +44,12 @@ export function SortableItemCard({
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        'relative',
+        // `isolate` keeps the editing controls' z-20 inside the card, where it
+        // belongs, instead of competing with the sticky header's z-index. The
+        // drag-time z-10 below is on this element rather than a descendant, so
+        // it still lifts the card above the header — which is what you want
+        // while dragging one.
+        'relative isolate',
         isDragging && 'z-10 opacity-80',
         editing && 'rounded-lg ring-2 ring-blue-400/50 ring-offset-2 ring-offset-black',
       )}

--- a/src/components/ui/item-slider.tsx
+++ b/src/components/ui/item-slider.tsx
@@ -2,8 +2,7 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 
-import { useIsClient } from '@/hooks/use-is-client';
-import { cn } from '@/lib/utils';
+import { useHasHover } from '@/hooks/use-has-hover';
 
 type ItemSliderProps = {
   children: ReactNode;
@@ -13,7 +12,7 @@ export function ItemSlider({ children }: ItemSliderProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(true);
-  const isClient = useIsClient();
+  const hasHover = useHasHover();
   const isDraggingRef = useRef(false);
   const startXRef = useRef(0);
   const scrollLeftRef = useRef(0);
@@ -95,8 +94,6 @@ export function ItemSlider({ children }: ItemSliderProps) {
     setShowRightArrow(container.scrollLeft < container.scrollWidth - container.clientWidth - 1);
   }
 
-  const disableArrows = isClient ? !window.matchMedia('(hover: hover)').matches : false;
-
   useEffect(() => {
     updateArrowVisibility();
   }, []);
@@ -121,37 +118,39 @@ export function ItemSlider({ children }: ItemSliderProps) {
     <div className="relative isolate">
       {showLeftArrow && (
         <>
-          <button
-            onClick={() => scroll('left')}
-            className={cn(
-              'absolute top-1/2 left-2 z-20 -translate-y-1/2 cursor-pointer rounded-full border border-muted-foreground/30 bg-background/80 p-2 transition-all hover:bg-muted/30',
-              { 'opacity-0': disableArrows },
-            )}
-          >
-            <span className="sr-only">Previous slide</span>
-            <ChevronLeft className="h-6 w-6" />
-          </button>
-          <div
-            className={`pointer-events-none absolute inset-y-0 -left-3 z-10 w-10 bg-linear-to-r from-background to-transparent lg:w-30 ${!showLeftArrow ? 'opacity-0' : ''}`}
-          />
+          {/*
+            Unmounted rather than hidden without a pointer: an opacity-0 button
+            still hit-tests and still takes focus, so it swallowed taps where it
+            overlapped the sticky header and put a Tab stop on a control nobody
+            could see. Arrow keys on the track below scroll the slider either
+            way, so touch loses no affordance. The edge fade stays — it is the
+            "more this way" hint, and it is the only one touch gets.
+          */}
+          {hasHover && (
+            <button
+              onClick={() => scroll('left')}
+              className="absolute top-1/2 left-2 z-20 -translate-y-1/2 cursor-pointer rounded-full border border-muted-foreground/30 bg-background/80 p-2 transition-all hover:bg-muted/30"
+            >
+              <span className="sr-only">Previous slide</span>
+              <ChevronLeft className="h-6 w-6" />
+            </button>
+          )}
+          <div className="pointer-events-none absolute inset-y-0 -left-3 z-10 w-10 bg-linear-to-r from-background to-transparent lg:w-30" />
         </>
       )}
 
       {showRightArrow && (
         <>
-          <button
-            onClick={() => scroll('right')}
-            className={cn(
-              'absolute top-1/2 right-2 z-20 -translate-y-1/2 cursor-pointer rounded-full border border-muted-foreground/30 bg-background/80 p-2 transition-all hover:bg-muted/30',
-              { 'opacity-0': disableArrows },
-            )}
-          >
-            <span className="sr-only">Next slide</span>
-            <ChevronRight className="h-6 w-6" />
-          </button>
-          <div
-            className={`pointer-events-none absolute inset-y-0 -right-3 z-10 w-10 bg-linear-to-l from-background to-transparent lg:w-30 ${!showRightArrow ? 'opacity-0' : ''}`}
-          />
+          {hasHover && (
+            <button
+              onClick={() => scroll('right')}
+              className="absolute top-1/2 right-2 z-20 -translate-y-1/2 cursor-pointer rounded-full border border-muted-foreground/30 bg-background/80 p-2 transition-all hover:bg-muted/30"
+            >
+              <span className="sr-only">Next slide</span>
+              <ChevronRight className="h-6 w-6" />
+            </button>
+          )}
+          <div className="pointer-events-none absolute inset-y-0 -right-3 z-10 w-10 bg-linear-to-l from-background to-transparent lg:w-30" />
         </>
       )}
 

--- a/src/components/ui/item-slider.tsx
+++ b/src/components/ui/item-slider.tsx
@@ -114,7 +114,11 @@ export function ItemSlider({ children }: ItemSliderProps) {
   }
 
   return (
-    <div className="relative">
+    // `isolate`: the scroll arrows (z-20) and edge fades (z-10) stack above the
+    // track, which is internal to the slider. Without a stacking context here
+    // they compete with the sticky header's z-index and paint over it as the
+    // slider scrolls past.
+    <div className="relative isolate">
       {showLeftArrow && (
         <>
           <button

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -314,7 +314,14 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
         // to *this* box (which never scrolls) instead of the viewport, i.e. not
         // stick at all. `clip` leaves `overflow-y: visible` alone and clips the
         // same horizontal overflow.
-        'relative flex w-full flex-1 flex-col overflow-x-clip bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        //
+        // `min-w-0` is required by that swap. As a flex item this box gets
+        // `min-width: auto`, which resolves to its min-content width — except
+        // on scroll containers, where it resolves to 0. `hidden` made it a
+        // scroll container and so shrank correctly for free; `clip` does not,
+        // so without this it refuses to shrink past its content and pushes the
+        // desktop layout into a horizontal scrollbar.
+        'relative flex w-full min-w-0 flex-1 flex-col overflow-x-clip bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
         className,
       )}
       {...props}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -308,7 +308,13 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        'relative flex w-full flex-1 flex-col overflow-x-hidden bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        // `overflow-x-clip`, not `hidden`: with `hidden` on one axis the other
+        // computes from `visible` to `auto`, which makes this element a scroll
+        // container — and the sticky header in the root layout would then stick
+        // to *this* box (which never scrolls) instead of the viewport, i.e. not
+        // stick at all. `clip` leaves `overflow-y: visible` alone and clips the
+        // same horizontal overflow.
+        'relative flex w-full flex-1 flex-col overflow-x-clip bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
         className,
       )}
       {...props}

--- a/src/hooks/use-has-hover.ts
+++ b/src/hooks/use-has-hover.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(hover: hover)';
+
+function subscribe(onChange: () => void) {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+}
+
+/**
+ * Whether the primary input device can hover — a mouse or trackpad rather than
+ * a touchscreen. Used to decide whether hover-only affordances are worth
+ * rendering at all.
+ *
+ * `useSyncExternalStore` for the same reason as {@link useIsMobile}: hydration
+ * renders see the server value, and the subscription means a device that gains
+ * a pointer (a tablet with a keyboard case attached) updates instead of keeping
+ * whatever was true at mount.
+ */
+export function useHasHover() {
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(QUERY).matches,
+    () => true,
+  );
+}


### PR DESCRIPTION
Pins the header (sidebar trigger + search) to the top of the viewport so
search stays reachable while scrolling.

Three things had to come along with it:

- `SidebarInset` (the header's parent) used `overflow-x-hidden`. With
  `hidden` on one axis, the other computes from `visible` to `auto`,
  making that element a scroll container — the header would have stuck to
  a box that never scrolls, i.e. not stuck at all, and only visibly so
  once the page was scrolled. `overflow-x-clip` clips the same horizontal
  overflow while leaving `overflow-y: visible` alone.
- `scroll-padding-top` on the root, sized from the new `--header-height`
  token, so anchor jumps (the discover skip link) and the post-pagination
  `scrollIntoView` land below the header instead of behind it.
- z-10 on the header: above page content, below the sidebar rail (z-20)
  so the rail's drag handle stays grabbable in the top 64px.

The pagination scroll spec's resting position moves down the document by
the header height; it now measures the header rather than hardcoding the
offset. New `e2e/sticky-header.spec.ts` covers pinning, the skip-link
landing position, and that both header controls stay clickable when
scrolled — running under both the desktop Chromium and mobile WebKit
projects.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XZuJig9qK5dP1mbN5nvSZT