### PR TITLE
⚡️ Cache genre lists harder with a dedicated long-lived profile

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,10 +21,12 @@ const nextConfig: NextConfig = {
     ];
   },
   cacheLife: {
-    biweekly: {
+    // Near-static data (e.g. TMDb genre lists). Served from cache indefinitely
+    // with a monthly background refresh; bust on demand via its cache tag.
+    genres: {
       stale: 60 * 60 * 24 * 14, // 14 days
-      revalidate: 60 * 60 * 24, // 1 day
-      expire: 60 * 60 * 24 * 14, // 14 days
+      revalidate: 60 * 60 * 24 * 30, // 30 days
+      expire: 60 * 60 * 24 * 365, // 1 year
     },
     privateShort: {
       stale: 60, // 1 minute

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,9 +21,10 @@ const nextConfig: NextConfig = {
     ];
   },
   cacheLife: {
-    // Near-static data (e.g. TMDb genre lists). Served from cache indefinitely
-    // with a monthly background refresh; bust on demand via its cache tag.
-    genres: {
+    // Data that essentially never changes (e.g. TMDb genre lists). Served from
+    // cache indefinitely with a monthly background refresh; bust on demand via
+    // the entry's cache tag.
+    nearStatic: {
       stale: 60 * 60 * 24 * 14, // 14 days
       revalidate: 60 * 60 * 24 * 30, // 30 days
       expire: 60 * 60 * 24 * 365, // 1 year

--- a/src/lib/media-actions.test.ts
+++ b/src/lib/media-actions.test.ts
@@ -2,12 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./movies', () => ({ fetchAvailableGenres: vi.fn() }));
 vi.mock('./tv-shows', () => ({ fetchAvailableTvGenres: vi.fn() }));
-vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
 
-import { revalidateTag } from 'next/cache';
-
-import { CACHE_TAGS } from './cache-tags';
-import { revalidateGenresCache, validateGenreForMediaType } from './media-actions';
+import { validateGenreForMediaType } from './media-actions';
 import { fetchAvailableGenres } from './movies';
 import { fetchAvailableTvGenres } from './tv-shows';
 
@@ -47,17 +43,5 @@ describe('validateGenreForMediaType', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-});
-
-describe('revalidateGenresCache', () => {
-  it('revalidates the movie genres tag', async () => {
-    await revalidateGenresCache('movie');
-    expect(revalidateTag).toHaveBeenCalledWith(CACHE_TAGS.public.genres.movies, 'max');
-  });
-
-  it('revalidates the tv genres tag', async () => {
-    await revalidateGenresCache('tv');
-    expect(revalidateTag).toHaveBeenCalledWith(CACHE_TAGS.public.genres.tv, 'max');
   });
 });

--- a/src/lib/media-actions.ts
+++ b/src/lib/media-actions.ts
@@ -1,9 +1,5 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
-
-import { CACHE_TAGS } from '@/lib/cache-tags';
-
 import { fetchAvailableGenres } from './movies';
 import { fetchAvailableTvGenres } from './tv-shows';
 
@@ -29,16 +25,4 @@ export async function validateGenreForMediaType(
     console.warn('Failed to validate genre for media type:', error);
     return true;
   }
-}
-
-/**
- * Revalidates the cache for available genres navigation when media type changes.
- *
- * @param mediaType - The media type to revalidate genres for, either 'movie' or 'tv'.
- */
-export async function revalidateGenresCache(mediaType: 'movie' | 'tv') {
-  revalidateTag(
-    mediaType === 'movie' ? CACHE_TAGS.public.genres.movies : CACHE_TAGS.public.genres.tv,
-    'max',
-  );
 }

--- a/src/lib/movies.ts
+++ b/src/lib/movies.ts
@@ -42,7 +42,7 @@ export async function fetchTrendingMovies() {
 export async function fetchAvailableGenres() {
   'use cache: remote';
   cacheTag(CACHE_TAGS.public.genres.movies);
-  cacheLife('biweekly');
+  cacheLife('genres');
 
   const movies = await tmdbFetch<GenreResponse>('/genre/movie/list', {
     errorMessage: 'Error loading genres',

--- a/src/lib/movies.ts
+++ b/src/lib/movies.ts
@@ -42,7 +42,7 @@ export async function fetchTrendingMovies() {
 export async function fetchAvailableGenres() {
   'use cache: remote';
   cacheTag(CACHE_TAGS.public.genres.movies);
-  cacheLife('genres');
+  cacheLife('nearStatic');
 
   const movies = await tmdbFetch<GenreResponse>('/genre/movie/list', {
     errorMessage: 'Error loading genres',

--- a/src/lib/tv-shows.ts
+++ b/src/lib/tv-shows.ts
@@ -208,7 +208,7 @@ export async function fetchPopularTvShows(region: string = DEFAULT_REGION) {
 export async function fetchAvailableTvGenres() {
   'use cache: remote';
   cacheTag(CACHE_TAGS.public.genres.tv);
-  cacheLife('biweekly');
+  cacheLife('genres');
 
   const tvGenres = await tmdbFetch<GenreResponse>('/genre/tv/list', {
     errorMessage: 'Error loading TV genres',

--- a/src/lib/tv-shows.ts
+++ b/src/lib/tv-shows.ts
@@ -208,7 +208,7 @@ export async function fetchPopularTvShows(region: string = DEFAULT_REGION) {
 export async function fetchAvailableTvGenres() {
   'use cache: remote';
   cacheTag(CACHE_TAGS.public.genres.tv);
-  cacheLife('genres');
+  cacheLife('nearStatic');
 
   const tvGenres = await tmdbFetch<GenreResponse>('/genre/tv/list', {
     errorMessage: 'Error loading TV genres',


### PR DESCRIPTION
## Summary

TMDb genre lists essentially never change, so this caches them much harder — without resorting to build-time fetching.

- Replace the `biweekly` cacheLife profile (its only users were the two genre fetchers) with a generic `nearStatic` profile in `next.config.ts`, reusable for any essentially-never-changing data: `stale` stays at 14 days, `revalidate` goes from 1 day → 30 days, and `expire` from 14 days → 1 year. Genres are now served from the remote cache indefinitely with a monthly background refresh, and there's no longer a blocking refetch after a two-week traffic lull.
- Point `fetchAvailableGenres` and `fetchAvailableTvGenres` at the new profile. The `public:genres:movies` / `public:genres:tv` cache tags are untouched, so `revalidateTag(...)` remains the on-demand escape hatch if TMDb ever changes the lists.
- Delete the dead `revalidateGenresCache` server action (nothing called it — and busting the genre cache on media-type change would have defeated the caching), along with its now-unused imports, tests, and the `next/cache` test mock.

## Testing

- `pnpm test` — 362/362 passing
- `pnpm lint` — clean
- `pnpm exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uNiKfuJz7xjQxMYuso96t